### PR TITLE
Update Travis CI to run tests and Rubocop rake task to not run on Production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 /log/*
 !/log/.keep
 /tmp
+
+# Ignore application configuration
+/config/application.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
 before_script:
   - psql -c 'create database team_endgame_test;' -U postgres
 script: 
+  - bundle exec rake 
   - bundle exec rake rubocop
 services:
   - postgresql # travic-ci default version at time of setup is 9.1

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,3 +1,5 @@
-require 'rubocop/rake_task'
+if %w(development test).include? Rails.env
+  require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new
+  RuboCop::RakeTask.new
+end 


### PR DESCRIPTION
I noticed that Travis CI was running Rubocop but wasn't running our tests, so I fixed that.  I also fixed an error that @gagaception and I noticed with Heroku regarding the Rubocop rake task.  It is now set to only run if `Rails.env` is development or test. 