### PR TITLE
Configure app to use Puma as server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,9 @@ gem 'devise'
 # Use Simple_form
 gem 'simple_form'
 
+# Use Puma for Application server
+gem 'puma'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
       ast (>= 1.1, < 3.0)
     pg (0.18.3)
     powerpack (0.1.1)
+    puma (2.15.3)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -188,6 +189,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   pg
+  puma
   rails (= 4.2.4)
   rubocop
   sass-rails (>= 3.2)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
+web: bundle exec puma -C config/puma.rb

--- a/config/database.yml
+++ b/config/database.yml
@@ -84,3 +84,4 @@ test:
 production:
   <<: *default
   database: team_endgame_production
+  pool: <%= ENV["DB_POOL"] || ENV['MAX_THREADS'] || 5 %>

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,192 @@
+#!/usr/bin/env puma
+
+workers Integer(ENV['WEB_CONCURRENCY'] || 1)
+threads_count = Integer(ENV['MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'
+
+on_worker_boot do
+  # Worker specific setup for Rails 4.1+
+  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+  ActiveRecord::Base.establish_connection
+end
+
+# The directory to operate out of.
+#
+# The default is the current directory.
+#
+# directory '/u/apps/lolcat'
+
+# Use an object or block as the rack application. This allows the
+# config file to be the application itself.
+#
+# app do |env|
+#   puts env
+#
+#   body = 'Hello, World!'
+#
+#   [200, { 'Content-Type' => 'text/plain', 'Content-Length' => body.length.to_s }, [body]]
+# end
+
+# Load "path" as a rackup file.
+#
+# The default is "config.ru".
+#
+# rackup '/u/apps/lolcat/config.ru'
+
+# Set the environment in which the rack's app will run. The value must be a string.
+#
+# The default is "development".
+#
+# environment 'production'
+
+# Daemonize the server into the background. Highly suggest that
+# this be combined with "pidfile" and "stdout_redirect".
+#
+# The default is "false".
+#
+# daemonize
+# daemonize false
+
+# Store the pid of the server in the file at "path".
+#
+# pidfile '/u/apps/lolcat/tmp/pids/puma.pid'
+
+# Use "path" as the file to store the server info state. This is
+# used by "pumactl" to query and control the server.
+#
+# state_path '/u/apps/lolcat/tmp/pids/puma.state'
+
+# Redirect STDOUT and STDERR to files specified. The 3rd parameter
+# ("append") specifies whether the output is appended, the default is
+# "false".
+#
+# stdout_redirect '/u/apps/lolcat/log/stdout', '/u/apps/lolcat/log/stderr'
+# stdout_redirect '/u/apps/lolcat/log/stdout', '/u/apps/lolcat/log/stderr', true
+
+# Disable request logging.
+#
+# The default is "false".
+#
+# quiet
+
+# Configure "min" to be the minimum number of threads to use to answer
+# requests and "max" the maximum.
+#
+# The default is "0, 16".
+#
+# threads 0, 16
+
+# Bind the server to "url". "tcp://", "unix://" and "ssl://" are the only
+# accepted protocols.
+#
+# The default is "tcp://0.0.0.0:9292".
+#
+# bind 'tcp://0.0.0.0:9292'
+# bind 'unix:///var/run/puma.sock'
+# bind 'unix:///var/run/puma.sock?umask=0111'
+# bind 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert'
+
+# Instead of "bind 'ssl://127.0.0.1:9292?key=path_to_key&cert=path_to_cert'" you
+# can also use the "ssl_bind" option.
+#
+# ssl_bind '127.0.0.1', '9292', { key: path_to_key, cert: path_to_cert }
+
+# Code to run before doing a restart. This code should
+# close log files, database connections, etc.
+#
+# This can be called multiple times to add code each time.
+#
+# on_restart do
+#   puts 'On restart...'
+# end
+
+# Command to use to restart puma. This should be just how to
+# load puma itself (ie. 'ruby -Ilib bin/puma'), not the arguments
+# to puma, as those are the same as the original process.
+#
+# restart_command '/u/app/lolcat/bin/restart_puma'
+
+# === Cluster mode ===
+
+# How many worker processes to run.
+#
+# The default is "0".
+#
+# workers 2
+
+# Code to run when a worker boots to setup the process before booting
+# the app.
+#
+# This can be called multiple times to add hooks.
+#
+# on_worker_boot do
+#   puts 'On worker boot...'
+# end
+
+# Code to run when a worker boots to setup the process after booting
+# the app.
+#
+# This can be called multiple times to add hooks.
+#
+# after_worker_boot do
+#   puts 'After worker boot...'
+# end
+
+# Code to run when a worker shutdown.
+#
+#
+# on_worker_shutdown do
+#   puts 'On worker shutdown...'
+# end
+
+# Allow workers to reload bundler context when master process is issued
+# a USR1 signal. This allows proper reloading of gems while the master
+# is preserved across a phased-restart. (incompatible with preload_app)
+# (off by default)
+
+# prune_bundler
+
+# Preload the application before starting the workers; this conflicts with
+# phased restart feature. (off by default)
+
+# preload_app!
+
+# Additional text to display in process listing
+#
+# tag 'app name'
+#
+# If you do not specify a tag, Puma will infer it. If you do not want Puma
+# to add a tag, use an empty string.
+
+# Verifies that all workers have checked in to the master process within
+# the given timeout. If not the worker process will be restarted. Default
+# value is 60 seconds.
+#
+# worker_timeout 60
+
+# Change the default worker timeout for booting
+#
+# If unspecified, this defaults to the value of worker_timeout.
+#
+# worker_boot_timeout 60
+
+# === Puma control rack application ===
+
+# Start the puma control rack application on "url". This application can
+# be communicated with to control the main server. Additionally, you can
+# provide an authentication token, so all requests to the control server
+# will need to include that token as a query parameter. This allows for
+# simple authentication.
+#
+# Check out https://github.com/puma/puma/blob/master/lib/puma/app/status.rb
+# to see what the app has available.
+#
+# activate_control_app 'unix:///var/run/pumactl.sock'
+# activate_control_app 'unix:///var/run/pumactl.sock', { auth_token: '12345' }
+# activate_control_app 'unix:///var/run/pumactl.sock', { no_token: true }


### PR DESCRIPTION
By default, Heroku is configured to use WEBrick, the application server that ships with Rails.  While WEBrick is fine for testing, it's certainly not right for production.  Heroku recommends [Puma](https://github.com/puma/puma), "a simple, fast, threaded, and highly concurrent HTTP 1.1 server for Ruby/Rack applications."

When this branch is merged, Puma will take over from WEBrick on both development and production.  It runs exactly the same as you're used to, though: `rails s -b 0.0.0.0` does the trick. 