### PR TITLE
Add generic piece horizontal, vertical, and diagonal checks

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -14,6 +14,25 @@ class Piece < ActiveRecord::Base
     end
   end
 
+  def horizontal_move?(row_dest, _col_dest)
+    row_position == row_dest
+  end
+
+  def vertical_move?(_row_dest, col_dest)
+    col_position == col_dest
+  end
+
+  def diagonal_move?(row_dest, col_dest)
+    row_diff = (row_position - row_dest).abs
+    col_diff = (col_position - col_dest).abs
+    row_diff == col_diff
+  end
+
+  # Checks if piece in destination already belongs to you
+  def own_piece?(row_dest, col_dest)
+    game.pieces.find_by(row_position: row_dest, col_position: col_dest, user_id: user_id).nil?
+  end
+
   # rubocop:disable Metrics/LineLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
   def obstructed?(row_dest, col_dest)
     # pass in row and col destination

--- a/test/models/king_test.rb
+++ b/test/models/king_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 class KingTest < ActiveSupport::TestCase
-  def create_game
+  def setup
     @user1 = FactoryGirl.create(:user)
     @user2 = FactoryGirl.create(:user)
     @g = Game.create(name: "New Game", white_player_id: @user1.id, black_player_id: @user2.id)
@@ -8,7 +8,6 @@ class KingTest < ActiveSupport::TestCase
   end
 
   test "outside destination" do
-    create_game
     # the last King that gets created on the board is a black king at position (7,4)
     @king1 = King.last
     expected = false
@@ -16,8 +15,7 @@ class KingTest < ActiveSupport::TestCase
     assert_equal expected, actual
   end
 
-  test "inside destination but blockated" do
-    create_game
+  test "inside destination but blocked" do
     # the last King that gets created on the board is a black king at position (7,4)
     @king1 = King.last
     expected = false
@@ -25,8 +23,7 @@ class KingTest < ActiveSupport::TestCase
     assert_equal expected, actual
   end
 
-  test "inside destination, not blockated" do
-    create_game
+  test "inside destination, not blocked" do
     # creating an extra white king in a location where it can move
     # rubocop:disable Metrics/LineLength
     @king1 = Piece.create(type: "King", row_position: 5, col_position: 4, user_id: @user1.id, game_id: @g.id)
@@ -35,8 +32,7 @@ class KingTest < ActiveSupport::TestCase
     assert_equal expected, actual
   end
 
-  test "inside destination, not blockated2" do
-    create_game
+  test "inside destination, not blocked 2" do
     # creating an extra black king in a location where it can move
     @king1 = Piece.create(type: "King", row_position: 5, col_position: 4, user_id: @user2.id, game_id: @g.id)
     expected = true

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -60,4 +60,50 @@ class PieceTest < ActiveSupport::TestCase
     actual = @bishop_white.obstructed?(2, 4)
     assert_equal expected, actual
   end
+
+  test "horizontal move" do
+    @rook_black = Piece.where(row_position: 7, col_position: 0).first
+    expected = true
+    actual = @rook_black.horizontal_move?(7, 3)
+    assert_equal expected, actual
+
+    expected = false
+    actual = @rook_black.horizontal_move?(5, 3)
+    assert_equal expected, actual
+  end
+
+  test "vertical move" do
+    @rook_black = Piece.where(row_position: 7, col_position: 0).first
+    expected = true
+    actual = @rook_black.vertical_move?(5, 0)
+    assert_equal expected, actual
+
+    expected = false
+    actual = @rook_black.vertical_move?(7, 3)
+    assert_equal expected, actual
+  end
+
+  test "diagonal move" do
+    @bishop_black = Piece.where(row_position: 7, col_position: 5).first
+    expected = true
+    actual = @bishop_black.diagonal_move?(5, 3)
+    assert_equal expected, actual
+
+    # testing a horizontal move
+    expected = false
+    actual = @bishop_black.diagonal_move?(7, 3)
+    assert_equal expected, actual
+
+    # testing a vertical move
+    expected = false
+    actual = @bishop_black.diagonal_move?(5, 5)
+    assert_equal expected, actual
+  end
+
+  test "own piece?" do
+    @bishop_black = Piece.where(row_position: 7, col_position: 5).first
+    expected = true
+    actual = @bishop_black.diagonal_move?(5, 3)
+    assert_equal expected, actual
+  end
 end


### PR DESCRIPTION
As @ronny2205 suggested, here are some generic tests for horizontal, vertical, and diagonal moves, along with a check for if you own the piece in the destination square.  Tests are included for everything.