### PR TITLE
Add obstructed? test to Bishop valid_move?

### DIFF
--- a/app/models/pieces/bishop.rb
+++ b/app/models/pieces/bishop.rb
@@ -2,7 +2,7 @@ class Bishop < Piece
   def valid_move?(row_dest, col_dest)
     # Bishop can only move diagonally
     # rubocop:disable Metrics/LineLength
-    return false if !self.diagonal_move?(row_dest, col_dest) || self.own_piece?(row_dest, col_dest)
+    return false if !self.diagonal_move?(row_dest, col_dest) || self.own_piece?(row_dest, col_dest) || self.obstructed?(row_dest, col_dest)
     true
   end
 end

--- a/test/models/bishop_test.rb
+++ b/test/models/bishop_test.rb
@@ -9,6 +9,9 @@ class BishopTest < ActiveSupport::TestCase
   end
 
   test "valid move for bishop" do
+    # Move pawn so Bishop is not obstructed
+    @pawn = @g.pieces.where(row_position: 6, col_position: 4, type: "Pawn").first
+    @pawn.move_to!(4, 4)
     expected = true
     actual = @black_bishop.valid_move?(5, 3)
     assert_equal expected, actual
@@ -23,6 +26,11 @@ class BishopTest < ActiveSupport::TestCase
     # Bishop moves horizontally
     expected = false
     actual = @black_bishop.valid_move?(5, 5)
+    assert_equal expected, actual
+
+    # Bishop is obstructed
+    expected = false
+    actual = @black_bishop.valid_move?(5, 3)
     assert_equal expected, actual
   end
 end


### PR DESCRIPTION
@ronny2205 pointed out that my Bishop `valid_move?` method wasn't checking if the piece was obstructed.  I fixed it and added a new test. 