### PR TITLE
Drag pieces

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,7 @@ gem 'coffee-rails', '~> 4.1.0'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
-# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem 'turbolinks'
+
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem 'figaro'
 # Use Puma for Application server
 gem 'puma'
 
+# Use Jquery-ui
+gem 'jquery-ui-rails'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,8 +184,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
-    turbolinks (2.5.3)
-      coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -220,6 +218,8 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   simple_form
   spring
-  turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (5.0.5)
+      railties (>= 3.2.16)
     json (1.8.3)
     jwt (1.5.2)
     loofah (2.0.3)
@@ -209,6 +211,7 @@ DEPENDENCIES
   figaro
   jbuilder (~> 2.0)
   jquery-rails
+  jquery-ui-rails
   omniauth-facebook
   pg
   puma

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,5 +13,4 @@
 //= require jquery
 //= require jquery_ujs
 //= require bootstrap-sprockets
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,3 +14,4 @@
 //= require jquery_ujs
 //= require bootstrap-sprockets
 //= require_tree .
+//= require jquery-ui

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -12,6 +12,7 @@
  *
  *= require_tree .
  *= require_self
+ *= require jquery-ui
  */
 @import "bootstrap-sprockets";
 @import "bootstrap";

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -8,8 +8,9 @@ class PiecesController < ApplicationController
   def update
     @piece = Piece.find(params[:id])
     @game = Game.find(@piece.game_id)
-    # rubocop:disable Metrics/LineLength
-    redirect_to game_path(@piece.game_id) if @piece.update_attributes(row_position: params[:row_position], col_position: params[:col_position]) && @game.update_attributes(turn_number: @game.turn_number + 1)
+    @piece.update_attributes(piece_params)
+    @game.update_attributes(turn_number: @game.turn_number + 1)
+    render :text => 'updated!'
   end
 
   def castle_kingside
@@ -34,5 +35,10 @@ class PiecesController < ApplicationController
       flash[:alert] = "You cannot castle" unless king.can_castle?(0, 0)
     end
     redirect_to game_path(@game)
+  end
+
+  private
+  def piece_params
+    params.require(:piece).permit(:type, :row_position, :col_position)
   end
 end

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -10,7 +10,7 @@ class PiecesController < ApplicationController
     @game = Game.find(@piece.game_id)
     @piece.update_attributes(piece_params)
     @game.update_attributes(turn_number: @game.turn_number + 1)
-    render :text => 'updated!'
+    render text: 'updated!'
   end
 
   def castle_kingside
@@ -38,6 +38,7 @@ class PiecesController < ApplicationController
   end
 
   private
+
   def piece_params
     params.require(:piece).permit(:type, :row_position, :col_position)
   end

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -6,8 +6,8 @@ module GamesHelper
       'Rook'   => '&#9814;',
       'Knight' => '&#9816;',
       'Bishop' => '&#9815;',
-      'Queen'  => '&#9812;',
-      'King' => '&#9813;'
+      'Queen'  => '&#9813;',
+      'King' => '&#9812;'
     }
 
     black_pieces = {
@@ -15,8 +15,8 @@ module GamesHelper
       'Rook'   => '&#9820;',
       'Knight' => '&#9822;',
       'Bishop' => '&#9821;',
-      'Queen'  => '&#9818;',
-      'King' => '&#9819;'
+      'Queen'  => '&#9819;',
+      'King' => '&#9818;'
     }
 
     @piece = pieces.find_by(row_position: row_pos, col_position: col_pos)

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -1,37 +1,31 @@
 module GamesHelper
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/LineLength
   def piece_present?(pieces, game, row_pos, col_pos)
+    white_pieces = {
+      'Pawn'   => '&#9817;',
+      'Rook'   => '&#9814;',
+      'Knight' => '&#9816;',
+      'Bishop' => '&#9815;',
+      'Queen'  => '&#9812;',
+      'King' => '&#9813;'
+    }
+
+    black_pieces = {
+      'Pawn'   => '&#9823;',
+      'Rook'   => '&#9820;',
+      'Knight' => '&#9822;',
+      'Bishop' => '&#9821;',
+      'Queen'  => '&#9818;',
+      'King' => '&#9819;'
+    }
+
     @piece = pieces.find_by(row_position: row_pos, col_position: col_pos)
     if @piece && @piece.user_id == game.white_player_id
-      case @piece.type
-      when "Pawn"
-        white_pawn(@piece, game)
-      when "Rook"
-        white_rook(@piece, game)
-      when "Knight"
-        white_knight(@piece, game)
-      when "Bishop"
-        white_bishop(@piece, game)
-      when "Queen"
-        white_queen(@piece, game)
-      when "King"
-        white_king(@piece, game)
-      end
+      return content_tag(:span, white_pieces[@piece.type].html_safe, class: %w(piece move_mode), id: "#{@piece.id}") if current_user.id == game.white_player_id && game.whos_turn? == game.white_player_id
+      return content_tag(:span, white_pieces[@piece.type].html_safe, class: ["piece"], id: "#{@piece.id}")
     elsif @piece && @piece.user_id == @game.black_player_id
-      case @piece.type
-      when "Pawn"
-        black_pawn(@piece, game)
-      when "Rook"
-        black_rook(@piece, game)
-      when "Knight"
-        black_knight(@piece, game)
-      when "Bishop"
-        black_bishop(@piece, game)
-      when "Queen"
-        black_queen(@piece, game)
-      when "King"
-        black_king(@piece, game)
-      end
+      return content_tag(:span, black_pieces[@piece.type].html_safe, class: %w(piece move_mode), id: "#{@piece.id}") if current_user.id == game.black_player_id && game.whos_turn? == game.black_player_id
+      return content_tag(:span, black_pieces[@piece.type].html_safe, class: ["piece"], id: "#{@piece.id}")
     end
   end
 
@@ -53,67 +47,5 @@ module GamesHelper
   def both_players_present?(game)
     return link_to game.name, game_path(game) unless game.black_player_id.nil?
     game.name + " - Waiting for second player"
-  end
-
-  private
-
-  def white_pawn(piece, game)
-    return link_to '&#9817;'.html_safe, piece_path(piece.id) if current_user.id == game.white_player_id && game.whos_turn? == game.white_player_id
-    return '&#9817;'.html_safe if current_user.id == game.black_player_id || game.whos_turn? != game.white_player_id
-  end
-
-  def white_rook(piece, game)
-    return link_to '&#9814;'.html_safe, piece_path(piece.id) if current_user.id == game.white_player_id && game.whos_turn? == game.white_player_id
-    return '&#9814;'.html_safe if current_user.id == game.black_player_id || game.whos_turn? != game.white_player_id
-  end
-
-  def white_knight(piece, game)
-    return link_to '&#9816;'.html_safe, piece_path(piece.id) if current_user.id == game.white_player_id && game.whos_turn? == game.white_player_id
-    return '&#9816;'.html_safe if current_user.id == game.black_player_id || game.whos_turn? != game.white_player_id
-  end
-
-  def white_bishop(piece, game)
-    return link_to '&#9815;'.html_safe, piece_path(piece.id) if current_user.id == game.white_player_id && game.whos_turn? == game.white_player_id
-    return '&#9815;'.html_safe if current_user.id == game.black_player_id || game.whos_turn? != game.white_player_id
-  end
-
-  def white_queen(piece, game)
-    return link_to '&#9812;'.html_safe, piece_path(piece.id) if current_user.id == game.white_player_id && game.whos_turn? == game.white_player_id
-    return '&#9812;'.html_safe if current_user.id == game.black_player_id || game.whos_turn? != game.white_player_id
-  end
-
-  def white_king(piece, game)
-    return link_to '&#9813;'.html_safe, piece_path(piece.id) if current_user.id == game.white_player_id && game.whos_turn? == game.white_player_id
-    return '&#9813;'.html_safe if current_user.id == game.black_player_id || game.whos_turn? != game.white_player_id
-  end
-
-  def black_pawn(piece, game)
-    return link_to '&#9823;'.html_safe, piece_path(piece.id) if current_user.id == game.black_player_id && game.whos_turn? == game.black_player_id
-    return '&#9823;'.html_safe if current_user.id == game.white_player_id || game.whos_turn? != game.black_player_id
-  end
-
-  def black_rook(piece, game)
-    return link_to '&#9820;'.html_safe, piece_path(piece.id) if current_user.id == game.black_player_id && game.whos_turn? == game.black_player_id
-    return '&#9820;'.html_safe if current_user.id == game.white_player_id || game.whos_turn? != game.black_player_id
-  end
-
-  def black_knight(piece, game)
-    return link_to '&#9822;'.html_safe, piece_path(piece.id) if current_user.id == game.black_player_id && game.whos_turn? == game.black_player_id
-    return '&#9822;'.html_safe if current_user.id == game.white_player_id || game.whos_turn? != game.black_player_id
-  end
-
-  def black_bishop(piece, game)
-    return link_to '&#9821;'.html_safe, piece_path(piece.id) if current_user.id == game.black_player_id && game.whos_turn? == game.black_player_id
-    return '&#9821;'.html_safe if current_user.id == game.white_player_id || game.whos_turn? != game.black_player_id
-  end
-
-  def black_queen(piece, game)
-    return link_to '&#9818;'.html_safe, piece_path(piece.id) if current_user.id == game.black_player_id && game.whos_turn? == game.black_player_id
-    return '&#9818;'.html_safe if current_user.id == game.white_player_id || game.whos_turn? != game.black_player_id
-  end
-
-  def black_king(piece, game)
-    return link_to '&#9819;'.html_safe, piece_path(piece.id) if current_user.id == game.black_player_id && game.whos_turn? == game.black_player_id
-    return '&#9819;'.html_safe if current_user.id == game.white_player_id || game.whos_turn? != game.black_player_id
   end
 end

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -20,12 +20,23 @@ module GamesHelper
     }
 
     @piece = pieces.find_by(row_position: row_pos, col_position: col_pos)
+    # if @piece && @piece.user_id == game.white_player_id
+    #   return content_tag(:span, white_pieces[@piece.type].html_safe, class: %w(piece move_mode), id: "#{@piece.id}") if current_user.id == game.white_player_id && game.whos_turn? == game.white_player_id
+    #   return content_tag(:span, white_pieces[@piece.type].html_safe, class: ["piece"], id: "#{@piece.id}")
+    # elsif @piece && @piece.user_id == @game.black_player_id
+    #   return content_tag(:span, black_pieces[@piece.type].html_safe, class: %w(piece move_mode), id: "#{@piece.id}") if current_user.id == game.black_player_id && game.whos_turn? == game.black_player_id
+    #   return content_tag(:span, black_pieces[@piece.type].html_safe, class: ["piece"], id: "#{@piece.id}")
+    # end
+
+    @piece = pieces.find_by(row_position: row_pos, col_position: col_pos)
     if @piece && @piece.user_id == game.white_player_id
-      return content_tag(:span, white_pieces[@piece.type].html_safe, class: %w(piece move_mode), id: "#{@piece.id}") if current_user.id == game.white_player_id && game.whos_turn? == game.white_player_id
-      return content_tag(:span, white_pieces[@piece.type].html_safe, class: ["piece"], id: "#{@piece.id}")
+      return content_tag(:span, white_pieces[@piece.type].html_safe, class: %w(piece move_mode), pos: "#{row_pos}#{col_pos}", id: "#{@piece.id}") if current_user.id == game.white_player_id && game.whos_turn? == game.white_player_id
+      return content_tag(:span, white_pieces[@piece.type].html_safe, class: ["piece"], pos: "#{row_pos}#{col_pos}", id: "#{@piece.id}")
     elsif @piece && @piece.user_id == @game.black_player_id
-      return content_tag(:span, black_pieces[@piece.type].html_safe, class: %w(piece move_mode), id: "#{@piece.id}") if current_user.id == game.black_player_id && game.whos_turn? == game.black_player_id
-      return content_tag(:span, black_pieces[@piece.type].html_safe, class: ["piece"], id: "#{@piece.id}")
+      return content_tag(:span, black_pieces[@piece.type].html_safe, class: %w(piece move_mode), pos: "#{row_pos}#{col_pos}", id: "#{@piece.id}") if current_user.id == game.black_player_id && game.whos_turn? == game.black_player_id
+      return content_tag(:span, black_pieces[@piece.type].html_safe, class: ["piece"], pos: "#{row_pos}#{col_pos}", id: "#{@piece.id}")
+    else
+      return tag(:span, class: ["piece"], pos: "#{row_pos}#{col_pos}")
     end
   end
 

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -20,15 +20,6 @@ module GamesHelper
     }
 
     @piece = pieces.find_by(row_position: row_pos, col_position: col_pos)
-    # if @piece && @piece.user_id == game.white_player_id
-    #   return content_tag(:span, white_pieces[@piece.type].html_safe, class: %w(piece move_mode), id: "#{@piece.id}") if current_user.id == game.white_player_id && game.whos_turn? == game.white_player_id
-    #   return content_tag(:span, white_pieces[@piece.type].html_safe, class: ["piece"], id: "#{@piece.id}")
-    # elsif @piece && @piece.user_id == @game.black_player_id
-    #   return content_tag(:span, black_pieces[@piece.type].html_safe, class: %w(piece move_mode), id: "#{@piece.id}") if current_user.id == game.black_player_id && game.whos_turn? == game.black_player_id
-    #   return content_tag(:span, black_pieces[@piece.type].html_safe, class: ["piece"], id: "#{@piece.id}")
-    # end
-
-    @piece = pieces.find_by(row_position: row_pos, col_position: col_pos)
     if @piece && @piece.user_id == game.white_player_id
       return content_tag(:span, white_pieces[@piece.type].html_safe, class: %w(piece move_mode), pos: "#{row_pos}#{col_pos}", id: "#{@piece.id}") if current_user.id == game.white_player_id && game.whos_turn? == game.white_player_id
       return content_tag(:span, white_pieces[@piece.type].html_safe, class: ["piece"], pos: "#{row_pos}#{col_pos}", id: "#{@piece.id}")

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,6 +1,6 @@
 <script>
 $(function() {
-  $('.piece .move_mode').draggable({ containment: '.board'});
+  $('.move_mode').draggable({ containment: '.board'});
   $( '.piece' ).droppable({
     drop: function( event, ui ) {
       $(ui.draggable).detach().css({top: 0,left: 0}).appendTo(this);
@@ -44,7 +44,10 @@ $(function() {
   <% 8.times do |row| %>
     <%= '<tr>'.html_safe %>
     <% 8.times do |col| %>
-      <%= '<td>'.html_safe + content_tag(:span, piece_present?(@pieces, @game, row, col), pos: "#{row}#{col}",class: ["piece"]) + '</td>'.html_safe %>
+      <%= '<td>'.html_safe + piece_present?(@pieces, @game, row, col) + '</td>'.html_safe %>
+
+      <!-- <%= '<td>'.html_safe + content_tag(:span, piece_present?(@pieces, @game, row, col), pos: "#{row}#{col}",class: ["piece"]) + '</td>'.html_safe %> -->
+
     <% end %> 
   <% end %>
 </table>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,31 +1,66 @@
 <script>
-  $(function() {
-    $('.piece .move_mode').draggable({ containment: '.board'});
-    $( '.piece' ).droppable({
-        drop: function( event, ui ) {
-          $(ui.draggable).detach().css({top: 0,left: 0}).appendTo(this);
-          var draggableId = ui.draggable.attr("id");
-          var droppableId = $(this).attr("pos");
-          var updateUrl = "/pieces/" + draggableId
-          var rowS = droppableId[0];
-          var colS = droppableId[1];
-          var row = parseInt(rowS);
-          var col = parseInt(colS);
+  // $(function() {
+  //   $('.piece .move_mode').draggable({ containment: '.board'});
+  //   $( '.piece' ).droppable({
+  //       drop: function( event, ui ) {
+  //         $(ui.draggable).detach().css({top: 0,left: 0}).appendTo(this);
+  //         var draggableId = ui.draggable.attr("id");
+  //         var droppableId = $(this).attr("pos");
+  //         var updateUrl = "/pieces/" + draggableId
+  //         var rowS = droppableId[0];
+  //         var colS = droppableId[1];
+  //         var row = parseInt(rowS);
+  //         var col = parseInt(colS);
 
-          alert("The piece with id: " + draggableId + " moved to row: " + row + " col: " + col);
+  //         alert("The piece with id: " + draggableId + " moved to row: " + row + " col: " + col);
         
-          $.ajax({
-            type: 'PUT',
-            url: updateUrl,
-            dataType: 'json',
-            data: { piece: { 
+  //         $.ajax({
+  //           type: 'PUT',
+  //           url: updateUrl,
+  //           dataType: 'json',
+  //           data: { piece: { 
+  //                 row_position: row, 
+  //                 col_position: col 
+  //           }}
+  //         });
+  //       }     
+  //   });  
+  // });
+
+
+
+$(function() {
+  $('.piece .move_mode').draggable({ containment: '.board'});
+     $( '.piece' ).droppable({
+      drop: function( event, ui ) {
+      $(ui.draggable).detach().css({top: 0,left: 0}).appendTo(this);
+      var draggableId = ui.draggable.attr("id");
+      var droppableId = $(this).attr("pos");
+      var updateUrl = "/pieces/" + draggableId
+      var rowS = droppableId[0];
+      var colS = droppableId[1];
+      var row = parseInt(rowS);
+      var col = parseInt(colS);
+
+
+        alert("The piece with id: " + draggableId + " moved to row: " + row + " col: " + col);
+        
+        $.ajax({
+          type: 'PUT',
+          url: updateUrl,
+          dataType: 'json',
+          data: { piece: { 
                   row_position: row, 
                   col_position: col 
-            }}
-          });
-        }     
-    });  
-  });
+          }}
+
+        });
+
+
+     }     
+  } );  
+
+});
 </script>
 
 <h1 class="text-center"><%= @game.name %></h1>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,65 +1,28 @@
 <script>
-  // $(function() {
-  //   $('.piece .move_mode').draggable({ containment: '.board'});
-  //   $( '.piece' ).droppable({
-  //       drop: function( event, ui ) {
-  //         $(ui.draggable).detach().css({top: 0,left: 0}).appendTo(this);
-  //         var draggableId = ui.draggable.attr("id");
-  //         var droppableId = $(this).attr("pos");
-  //         var updateUrl = "/pieces/" + draggableId
-  //         var rowS = droppableId[0];
-  //         var colS = droppableId[1];
-  //         var row = parseInt(rowS);
-  //         var col = parseInt(colS);
-
-  //         alert("The piece with id: " + draggableId + " moved to row: " + row + " col: " + col);
-        
-  //         $.ajax({
-  //           type: 'PUT',
-  //           url: updateUrl,
-  //           dataType: 'json',
-  //           data: { piece: { 
-  //                 row_position: row, 
-  //                 col_position: col 
-  //           }}
-  //         });
-  //       }     
-  //   });  
-  // });
-
-
-
 $(function() {
   $('.piece .move_mode').draggable({ containment: '.board'});
-     $( '.piece' ).droppable({
-      drop: function( event, ui ) {
+  $( '.piece' ).droppable({
+    drop: function( event, ui ) {
       $(ui.draggable).detach().css({top: 0,left: 0}).appendTo(this);
       var draggableId = ui.draggable.attr("id");
       var droppableId = $(this).attr("pos");
       var updateUrl = "/pieces/" + draggableId
-      var rowS = droppableId[0];
-      var colS = droppableId[1];
-      var row = parseInt(rowS);
-      var col = parseInt(colS);
+      var row = droppableId[0];
+      var col = droppableId[1];
 
-
-        alert("The piece with id: " + draggableId + " moved to row: " + row + " col: " + col);
+      alert("The piece with id: " + draggableId + " moved to row: " + row + " col: " + col);
         
-        $.ajax({
-          type: 'PUT',
-          url: updateUrl,
-          dataType: 'json',
-          data: { piece: { 
-                  row_position: row, 
-                  col_position: col 
-          }}
-
-        });
-
-
-     }     
-  } );  
-
+      $.ajax({
+        type: 'PUT',
+        url: updateUrl,
+        dataType: 'json',
+        data: { piece: { 
+                row_position: row, 
+                col_position: col 
+        }}
+      });
+    }     
+  });  
 });
 </script>
 

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,3 +1,33 @@
+<script>
+  $(function() {
+    $('.piece .move_mode').draggable({ containment: '.board'});
+    $( '.piece' ).droppable({
+        drop: function( event, ui ) {
+          $(ui.draggable).detach().css({top: 0,left: 0}).appendTo(this);
+          var draggableId = ui.draggable.attr("id");
+          var droppableId = $(this).attr("pos");
+          var updateUrl = "/pieces/" + draggableId
+          var rowS = droppableId[0];
+          var colS = droppableId[1];
+          var row = parseInt(rowS);
+          var col = parseInt(colS);
+
+          alert("The piece with id: " + draggableId + " moved to row: " + row + " col: " + col);
+        
+          $.ajax({
+            type: 'PUT',
+            url: updateUrl,
+            dataType: 'json',
+            data: { piece: { 
+                  row_position: row, 
+                  col_position: col 
+            }}
+          });
+        }     
+    });  
+  });
+</script>
+
 <h1 class="text-center"><%= @game.name %></h1>
 <br/>
 <h2 class="text-center"><%= turn %></h2>
@@ -16,7 +46,7 @@
   <% 8.times do |row| %>
     <%= '<tr>'.html_safe %>
     <% 8.times do |col| %>
-      <%= '<td>'.html_safe + content_tag(:span, piece_present?(@pieces, @game, row, col), class: ["piece"]) + '</td>'.html_safe %>
+      <%= '<td>'.html_safe + content_tag(:span, piece_present?(@pieces, @game, row, col), pos: "#{row}#{col}",class: ["piece"]) + '</td>'.html_safe %>
     <% end %> 
   <% end %>
 </table>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -9,8 +9,6 @@ $(function() {
       var updateUrl = "/pieces/" + draggableId
       var row = droppableId[0];
       var col = droppableId[1];
-
-      alert("The piece with id: " + draggableId + " moved to row: " + row + " col: " + col);
         
       $.ajax({
         type: 'PUT',
@@ -45,9 +43,6 @@ $(function() {
     <%= '<tr>'.html_safe %>
     <% 8.times do |col| %>
       <%= '<td>'.html_safe + piece_present?(@pieces, @game, row, col) + '</td>'.html_safe %>
-
-      <!-- <%= '<td>'.html_safe + content_tag(:span, piece_present?(@pieces, @game, row, col), pos: "#{row}#{col}",class: ["piece"]) + '</td>'.html_safe %> -->
-
     <% end %> 
   <% end %>
 </table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>TeamEndgame</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => false %>
+  <%= javascript_include_tag 'application', 'data-turbolinks-track' => false %>
   <%= csrf_meta_tags %>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>

--- a/test/controllers/pieces_controller_test.rb
+++ b/test/controllers/pieces_controller_test.rb
@@ -3,8 +3,10 @@ require 'test_helper'
 class PiecesControllerTest < ActionController::TestCase
   def setup
     @user = FactoryGirl.create(:user)
-    @g = Game.create(name: "Test", white_player_id: @user.id, turn_number: 0)
-    @piece = Piece.create(type: "Pawn", col_position: 1, row_position: 1, user_id: @user.id, game_id: @g.id)
+    @g = Game.create(name: "Test", white_player_id: @user.id, black_player_id: 3, turn_number: 0)
+    @pawn = Piece.create(type: "Pawn", col_position: 1, row_position: 1, user_id: @user.id, game_id: @g.id)
+    @white_rook_queenside = Piece.create(type: "Rook", col_position: 0, row_position: 0, user_id: @user.id, game_id: @g.id)
+    @white_rook_kingside = Piece.create(type: "Rook", col_position: 7, row_position: 0, user_id: @user.id, game_id: @g.id)
   end
 
   # test "should get show" do
@@ -13,16 +15,61 @@ class PiecesControllerTest < ActionController::TestCase
   #   assert_response :success
   # end
 
-  # test "should update piece location" do
-  #   sign_in @user
-  #   put :update, id: @piece.id, col_position: 2, row_position: 2
-  #   @piece.reload
+  test "should update piece location" do
+    sign_in @user
+    put :update, id: @pawn.id, piece: { type: @pawn.type, col_position: 2, row_position: 2 }
+    @pawn.reload
+    @g.reload
 
-  #   expected_row_position = 2
-  #   expected_col_position = 2
-  #   assert_equal expected_col_position, @piece.col_position
-  #   assert_equal expected_row_position, @piece.row_position
+    # Test for new position of pawn
+    expected_row_position = 2
+    expected_col_position = 2
+    assert_equal expected_col_position, @pawn.col_position
+    assert_equal expected_row_position, @pawn.row_position
 
-  #   assert_redirected_to game_path(@piece.game_id)
-  # end
+    # Test that turn number updated
+    assert_equal 1, @g.turn_number
+
+    assert render_template: { text: 'updated!' }
+  end
+
+  test "should allow white player to castle queenside" do
+    sign_in @user
+    @white_king = Piece.create(type: "King", col_position: 4, row_position: 0, user_id: @user.id, game_id: @g.id)
+    get :castle_queenside, game_id: @g.id
+
+    assert flash[:alert].nil?
+
+    assert_redirected_to game_path(@g.id)
+  end
+
+  test "should allow white player to castle kingside" do
+    sign_in @user
+    @white_king = Piece.create(type: "King", col_position: 4, row_position: 0, user_id: @user.id, game_id: @g.id)
+    get :castle_kingside, game_id: @g.id
+
+    assert flash[:alert].nil?
+
+    assert_redirected_to game_path(@g.id)
+  end
+
+  test "should have flash error when white player tries to castle queenside" do
+    sign_in @user
+    @white_king_moved = Piece.create(type: "King", col_position: 4, row_position: 0, user_id: @user.id, game_id: @g.id, moved: true)
+
+    get :castle_queenside, game_id: @g.id
+
+    assert_not flash[:alert].nil?
+    assert_redirected_to game_path(@g.id)
+  end
+
+  test "should have flash error when white player tries to castle kingside" do
+    sign_in @user
+    @white_king_moved = Piece.create(type: "King", col_position: 4, row_position: 0, user_id: @user.id, game_id: @g.id, moved: true)
+
+    get :castle_kingside, game_id: @g.id
+
+    assert_not flash[:alert].nil?
+    assert_redirected_to game_path(@g.id)
+  end
 end

--- a/test/controllers/pieces_controller_test.rb
+++ b/test/controllers/pieces_controller_test.rb
@@ -7,22 +7,22 @@ class PiecesControllerTest < ActionController::TestCase
     @piece = Piece.create(type: "Pawn", col_position: 1, row_position: 1, user_id: @user.id, game_id: @g.id)
   end
 
-  test "should get show" do
-    sign_in @user
-    get :show, id: @piece.id
-    assert_response :success
-  end
+  # test "should get show" do
+  #   sign_in @user
+  #   get :show, id: @piece.id
+  #   assert_response :success
+  # end
 
-  test "should update piece location" do
-    sign_in @user
-    put :update, id: @piece.id, col_position: 2, row_position: 2
-    @piece.reload
+  # test "should update piece location" do
+  #   sign_in @user
+  #   put :update, id: @piece.id, col_position: 2, row_position: 2
+  #   @piece.reload
 
-    expected_row_position = 2
-    expected_col_position = 2
-    assert_equal expected_col_position, @piece.col_position
-    assert_equal expected_row_position, @piece.row_position
+  #   expected_row_position = 2
+  #   expected_col_position = 2
+  #   assert_equal expected_col_position, @piece.col_position
+  #   assert_equal expected_row_position, @piece.row_position
 
-    assert_redirected_to game_path(@piece.game_id)
-  end
+  #   assert_redirected_to game_path(@piece.game_id)
+  # end
 end


### PR DESCRIPTION
Aziz and I enabled moving pieces with JS.
This is what it does/doesn't do:
1. Each player can move their pieces on their turn. (Any type of piece)
2. The new location of the piece is updated into the database.
3. The piece can't go outside of the board and does go to the middle of the square (it was a bit hard to implement :) )
 4. One problem - if a piece tries to land on an occupied square the ui moves it to a different square, but the location that is saved to the database is the one the piece tried to land on.
We couldn't figure out yet how to fix it.
5. It partly supports turns:
The turn number is updated to the database, but there is a bug here - it lets the next player play only if manually refreshing the page. We didn't take care of it yet. (Take, we saw it's your task, we can work on it together if you'd like)
6. We didn't delete the piece show page yet. (Tha app doesn't use it, but In case we want to use some of this code later).
7. We didn't write tests yet. If anybody has an idea for a good test, please tell us.
(We commented the old tests in the piece contreller test file)


One more thing - 
I refactored part of the code that draws pieces on the board (in the game_helper), using a hash.