### PR TITLE
Valid move pawn

### DIFF
--- a/app/models/pieces/pawn.rb
+++ b/app/models/pieces/pawn.rb
@@ -1,22 +1,19 @@
 class Pawn < Piece
-  # rubocop:disable Metrics/LineLength 
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/LineLength
   def valid_move?(row_dest, col_dest)
-  	row_diff = (row_position - row_dest).abs
+    row_diff = (row_position - row_dest).abs
     col_diff = (col_position - col_dest).abs
     return false if self.backward_move?(row_dest, col_dest) || self.horizontal_move?(row_dest, col_dest)
-    return true if self.diagonal_move?(row_dest, col_dest) &&  col_diff == 1 && row_diff == 1 && game.pieces.find_by(row_position: row_dest, col_position: col_dest) && !self.own_piece?(row_dest, col_dest)
-  	if self.vertical_move?(row_dest, col_dest) && !game.pieces.find_by(row_position: row_dest, col_position: col_dest) 
-  	  return false if row_diff > 2
-  	  return true if row_position == 1 || row_position == 6 && row_diff <= 2
- 	  return true if row_diff == 1
-   	end 	
-    return false
+    return true if self.diagonal_move?(row_dest, col_dest) && col_diff == 1 && row_diff == 1 && game.pieces.find_by(row_position: row_dest, col_position: col_dest) && !self.own_piece?(row_dest, col_dest)
+    if self.vertical_move?(row_dest, col_dest) && !game.pieces.find_by(row_position: row_dest, col_position: col_dest)
+      return false if row_diff > 2
+      return true if row_position == 1 || row_position == 6 && row_diff <= 2
+      return true if row_diff == 1
+    end
+    false
   end
 
-  def backward_move?(row_dest, col_dest)
-  	self.user_id == self.game.white_player_id ? row_position > row_dest : row_position < row_dest
+  def backward_move?(row_dest, _col_dest)
+    user_id == game.white_player_id ? row_position > row_dest : row_position < row_dest
   end
 end
-
-
-

--- a/app/models/pieces/pawn.rb
+++ b/app/models/pieces/pawn.rb
@@ -3,23 +3,18 @@ class Pawn < Piece
   def valid_move?(row_dest, col_dest)
   	row_diff = (row_position - row_dest).abs
     col_diff = (col_position - col_dest).abs
-    return false if self.backward_move?(row_dest, col_dest) || self.obstructed?(row_dest, col_dest)
-  	return true if self.diagonal_move?(row_dest, col_dest) &&  col_diff == 1 && row_diff == 1 && game.pieces.find_by(row_position: row_dest, col_position: col_dest) && !self.own_piece?(row_dest, col_dest)
+    return false if self.backward_move?(row_dest, col_dest) || self.horizontal_move?(row_dest, col_dest)
+    return true if self.diagonal_move?(row_dest, col_dest) &&  col_diff == 1 && row_diff == 1 && game.pieces.find_by(row_position: row_dest, col_position: col_dest) && !self.own_piece?(row_dest, col_dest)
   	if self.vertical_move?(row_dest, col_dest) && !game.pieces.find_by(row_position: row_dest, col_position: col_dest) 
-  	  if row_position == 1 || row_position == 6 
-  	      return true if row_diff <= 2
-  	  elsif row_diff == 1
-  	      return true
-  	  else
-  	      return false
-  	  end	 
-  	end 
-  	return false 		
+  	  return false if row_diff > 2
+  	  return true if row_position == 1 || row_position == 6 && row_diff <= 2
+ 	  return true if row_diff == 1
+   	end 	
+    return false
   end
 
   def backward_move?(row_dest, col_dest)
-  	@piece = Piece.find_by(row_position: row_dest, col_position: col_dest)
-  	@piece && @piece.user_id == @piece.game.white_player_id ? row_dest < row_position : row_dest > row_position
+  	self.user_id == self.game.white_player_id ? row_position > row_dest : row_position < row_dest
   end
 end
 

--- a/app/models/pieces/pawn.rb
+++ b/app/models/pieces/pawn.rb
@@ -1,2 +1,27 @@
 class Pawn < Piece
+  # rubocop:disable Metrics/LineLength 
+  def valid_move?(row_dest, col_dest)
+  	row_diff = (row_position - row_dest).abs
+    col_diff = (col_position - col_dest).abs
+    return false if self.backward_move?(row_dest, col_dest) || self.obstructed?(row_dest, col_dest)
+  	return true if self.diagonal_move?(row_dest, col_dest) &&  col_diff == 1 && row_diff == 1 && game.pieces.find_by(row_position: row_dest, col_position: col_dest) && !self.own_piece?(row_dest, col_dest)
+  	if self.vertical_move?(row_dest, col_dest) && !game.pieces.find_by(row_position: row_dest, col_position: col_dest) 
+  	  if row_position == 1 || row_position == 6 
+  	      return true if row_diff <= 2
+  	  elsif row_diff == 1
+  	      return true
+  	  else
+  	      return false
+  	  end	 
+  	end 
+  	return false 		
+  end
+
+  def backward_move?(row_dest, col_dest)
+  	@piece = Piece.find_by(row_position: row_dest, col_position: col_dest)
+  	@piece && @piece.user_id == @piece.game.white_player_id ? row_dest < row_position : row_dest > row_position
+  end
 end
+
+
+

--- a/test/models/pawn_test.rb
+++ b/test/models/pawn_test.rb
@@ -1,0 +1,76 @@
+require 'test_helper'
+class PawnTest < ActiveSupport::TestCase
+  def setup
+    @user1 = FactoryGirl.create(:user)
+    @user2 = FactoryGirl.create(:user)
+    @g = Game.create(name: "New Game", white_player_id: @user1.id, black_player_id: @user2.id)
+    @g.populate_board!
+  end
+
+  test "pawn valid move" do
+  	#First pawn - is white pawn whit position (1,7)
+    @pawn1 = Pawn.first
+    expected = true
+    actual = @pawn1.valid_move?(2, 7)
+    assert_equal expected, actual
+    #Last pawn - is black pawn whit position (6,0)
+    @pawn2 = Pawn.last
+    expected = true
+    actual = @pawn2.valid_move?(4, 0)
+    assert_equal expected, actual
+
+  end
+
+  test "pawn invalid move" do
+    #First pawn - is white pawn whit position (1,7)
+    @pawn = Pawn.first
+    expected = false
+    actual = @pawn.valid_move?(4, 7)
+    assert_equal expected, actual
+  end
+
+   test "valid diagonal move" do
+     @pawn1 = Pawn.create(type: "Pawn", row_position: 4, col_position: 2, user_id: @user1.id, game_id: @g.id)
+     @pawn2 = Pawn.create(type: "Pawn", row_position: 5, col_position: 3, user_id: @user2.id, game_id: @g.id)
+     expected = true
+     actual = @pawn1.valid_move?(5, 3)
+     assert_equal expected, actual
+   end
+
+  # test "invalid diagonal move" do
+  #   @pawn1 = Pawn.create(type: "Pawn", row_position: 4, col_position: 5, user_id: @user1.id, game_id: @g.id)
+  #   @pawn2 = Pawn.create(type: "Pawn", row_position: 3, col_position: 6, user_id: @user2.id, game_id: @g.id)
+  #   expected = false
+  #   actual = @pawn1.valid_move?(3, 6)
+  #   assert_equal expected, actual
+  # end
+
+  # test "invalid diagonal move" do
+  #   @pawn1 = Pawn.create(type: "Pawn", row_position: 4, col_position: 5, user_id: @user1.id, game_id: @g.id)
+  #   expected = false
+  #   actual = @pawn1.valid_move?(5, 4)
+  #   assert_equal expected, actual
+  # end
+
+  test "horizontal move to pawn" do
+    @pawn = Pawn.create(type: "Pawn", row_position: 5, col_position: 0, user_id: @user2.id, game_id: @g.id)
+    expected = false
+    actual = @pawn.valid_move?(5, 1)
+    assert_equal expected, actual
+  end
+
+  test "backward move to black pawn" do
+    @pawn = Pawn.create(type: "Pawn", row_position: 4, col_position: 0, user_id: @user2.id, game_id: @g.id)
+    expected = false
+    actual = @pawn.backward_move?(5, 0)
+    assert_equal expected, actual
+  end
+
+  test " white pawn backward move" do
+    @pawn1 = Pawn.create(type: "Pawn", row_position: 4, col_position: 0, user_id: @user1.id, game_id: @g.id)
+    expected = false
+    actual = @pawn1.backward_move?(3, 0)
+    assert_equal expected, actual
+  end
+
+end

--- a/test/models/pawn_test.rb
+++ b/test/models/pawn_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 class PawnTest < ActiveSupport::TestCase
+  # rubocop:disable Metrics/LineLength
   def setup
     @user1 = FactoryGirl.create(:user)
     @user2 = FactoryGirl.create(:user)
@@ -8,12 +9,10 @@ class PawnTest < ActiveSupport::TestCase
   end
 
   test "pawn valid move" do
-  	#First pawn - is white pawn whit position (1,7)
     @pawn1 = Pawn.first
     expected = true
     actual = @pawn1.valid_move?(2, 7)
     assert_equal expected, actual
-    #Last pawn - is black pawn whit position (6,0)
     @pawn2 = Pawn.last
     expected = true
     actual = @pawn2.valid_move?(4, 0)
@@ -21,20 +20,19 @@ class PawnTest < ActiveSupport::TestCase
   end
 
   test "pawn invalid move" do
-    #First pawn - is white pawn whit position (1,7)
     @pawn = Pawn.first
     expected = false
     actual = @pawn.valid_move?(4, 7)
     assert_equal expected, actual
   end
 
-   test "valid diagonal killing move" do
-     @pawn1 = Pawn.create(type: "Pawn", row_position: 4, col_position: 2, user_id: @user1.id, game_id: @g.id)
-     @pawn2 = Pawn.create(type: "Pawn", row_position: 5, col_position: 3, user_id: @user2.id, game_id: @g.id)
-     expected = true
-     actual = @pawn1.valid_move?(5, 3)
-     assert_equal expected, actual
-   end
+  test "valid diagonal killing move" do
+    @pawn1 = Pawn.create(type: "Pawn", row_position: 4, col_position: 2, user_id: @user1.id, game_id: @g.id)
+    @pawn2 = Pawn.create(type: "Pawn", row_position: 5, col_position: 3, user_id: @user2.id, game_id: @g.id)
+    expected = true
+    actual = @pawn1.valid_move?(5, 3)
+    assert_equal expected, actual
+  end
 
   test "invalid diagonal killing move" do
     @pawn1 = Pawn.create(type: "Pawn", row_position: 4, col_position: 5, user_id: @user1.id, game_id: @g.id)
@@ -71,5 +69,4 @@ class PawnTest < ActiveSupport::TestCase
     actual = @pawn1.valid_move?(3, 0)
     assert_equal expected, actual
   end
-
 end

--- a/test/models/pawn_test.rb
+++ b/test/models/pawn_test.rb
@@ -18,7 +18,6 @@ class PawnTest < ActiveSupport::TestCase
     expected = true
     actual = @pawn2.valid_move?(4, 0)
     assert_equal expected, actual
-
   end
 
   test "pawn invalid move" do
@@ -29,7 +28,7 @@ class PawnTest < ActiveSupport::TestCase
     assert_equal expected, actual
   end
 
-   test "valid diagonal move" do
+   test "valid diagonal killing move" do
      @pawn1 = Pawn.create(type: "Pawn", row_position: 4, col_position: 2, user_id: @user1.id, game_id: @g.id)
      @pawn2 = Pawn.create(type: "Pawn", row_position: 5, col_position: 3, user_id: @user2.id, game_id: @g.id)
      expected = true
@@ -37,39 +36,39 @@ class PawnTest < ActiveSupport::TestCase
      assert_equal expected, actual
    end
 
-  # test "invalid diagonal move" do
-  #   @pawn1 = Pawn.create(type: "Pawn", row_position: 4, col_position: 5, user_id: @user1.id, game_id: @g.id)
-  #   @pawn2 = Pawn.create(type: "Pawn", row_position: 3, col_position: 6, user_id: @user2.id, game_id: @g.id)
-  #   expected = false
-  #   actual = @pawn1.valid_move?(3, 6)
-  #   assert_equal expected, actual
-  # end
+  test "invalid diagonal killing move" do
+    @pawn1 = Pawn.create(type: "Pawn", row_position: 4, col_position: 5, user_id: @user1.id, game_id: @g.id)
+    @pawn2 = Pawn.create(type: "Pawn", row_position: 3, col_position: 6, user_id: @user2.id, game_id: @g.id)
+    expected = false
+    actual = @pawn1.valid_move?(3, 6)
+    assert_equal expected, actual
+  end
 
-  # test "invalid diagonal move" do
-  #   @pawn1 = Pawn.create(type: "Pawn", row_position: 4, col_position: 5, user_id: @user1.id, game_id: @g.id)
-  #   expected = false
-  #   actual = @pawn1.valid_move?(5, 4)
-  #   assert_equal expected, actual
-  # end
+  test "invalid diagonal move" do
+    @pawn1 = Pawn.create(type: "Pawn", row_position: 4, col_position: 5, user_id: @user1.id, game_id: @g.id)
+    expected = false
+    actual = @pawn1.valid_move?(5, 4)
+    assert_equal expected, actual
+  end
 
-  test "horizontal move to pawn" do
+  test "horizontal move" do
     @pawn = Pawn.create(type: "Pawn", row_position: 5, col_position: 0, user_id: @user2.id, game_id: @g.id)
     expected = false
     actual = @pawn.valid_move?(5, 1)
     assert_equal expected, actual
   end
 
-  test "backward move to black pawn" do
+  test "black pawn backward move" do
     @pawn = Pawn.create(type: "Pawn", row_position: 4, col_position: 0, user_id: @user2.id, game_id: @g.id)
     expected = false
-    actual = @pawn.backward_move?(5, 0)
+    actual = @pawn.valid_move?(5, 0)
     assert_equal expected, actual
   end
 
   test " white pawn backward move" do
     @pawn1 = Pawn.create(type: "Pawn", row_position: 4, col_position: 0, user_id: @user1.id, game_id: @g.id)
     expected = false
-    actual = @pawn1.backward_move?(3, 0)
+    actual = @pawn1.valid_move?(3, 0)
     assert_equal expected, actual
   end
 


### PR DESCRIPTION
- added all rules where pawn can move: 
 1. pawn can move only forward
 2. pawn can move diagonally only when it kills opponents piece
 3. if pawn wasn't moved before it can make 2 steps forward
- added tests 