### PR TITLE
En Passant

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -2,50 +2,18 @@ class Piece < ActiveRecord::Base
   belongs_to :user
   belongs_to :game
 
-  # Validate move of en passant
-  # Move_to! if piece is next to a pawn and the piece is a pawn
-  # check if en passant is possible
-
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/LineLength, Metrics/PerceivedComplexity, Metrics/MethodLength
   def move_to!(new_row, new_col)
     @piece = Piece.find_by(row_position: new_row, col_position: new_col)
-    check_adjacent_pieces(new_row, new_col) unless @piece
+    if type == "Pawn" && check_adjacent_pieces(new_row, new_col)
+      capture_en_passant!(new_row, new_col, @last_updated)
+    end
     update(row_position: new_row, col_position: new_col, moved: true) && return unless @piece
     if @piece.user_id != user_id
       @piece.update(row_position: nil, col_position: nil, captured: true)
       update(row_position: new_row, col_position: new_col, moved: true)
     else
       check_if_castling(new_row, new_col)
-    end
-  end
-
-  def check_adjacent_pieces(new_row, new_col)
-    @last_updated = Piece.where(game_id: game_id).order("updated_at desc").first
-    @adjacent_piece_r = Piece.find_by(row_position: row_position, col_position: col_position + 1) if col_position != 7
-    @adjacent_piece_l = Piece.find_by(row_position: row_position, col_position: col_position - 1) if col_position != 0
-    if type == "Pawn" && @adjacent_piece_r && @adjacent_piece_r.type == "Pawn"
-      check_en_passant(new_row, new_col, @adjacent_piece_r, @last_updated) if capture_en_passant!(new_row, new_col, @last_updated)
-    elsif type == "Pawn" && @adjacent_piece_l && @adjacent_piece_l.type == "Pawn"
-      check_en_passant(new_row, new_col, @adjacent_piece_l, @last_updated) if capture_en_passant!(new_row, new_col, @last_updated)
-    end
-  end
-
-  def check_en_passant(row_dest, col_dest, adjacent_pawn, last_updated)
-    return false if last_updated != adjacent_pawn || last_updated.previous_changes_hash.nil? || last_updated.previous_changes_hash["moved"].nil? || last_updated.previous_changes_hash["row_position"].nil?
-    @last_updated_row = eval( last_updated.previous_changes_hash["row_position"].gsub(/(\w+?)/, "'\\1'") )
-    @last_updated_moved = eval( last_updated.previous_changes_hash["moved"].gsub(/(\w+?)/, "'\\1'") )
-    return false unless (@last_updated_row[0].to_i - @last_updated_row[1].to_i).abs == 2 && @last_updated_moved
-    return true if Game.find(game_id).black_player_id == user_id && row_dest == last_updated.row_position - 1 && col_dest == last_updated.col_position
-    return true if Game.find(game_id).black_player_id != user_id && row_dest == last_updated.row_position + 1 && col_dest == last_updated.col_position
-    false
-  end
-
-  def capture_en_passant!(row_dest, col_dest, last_updated)
-    if Game.find(game_id).black_player_id == user_id && row_dest == last_updated.row_position - 1 && col_dest == last_updated.col_position
-      last_updated.update(row_position: nil, col_position: nil, captured: true)
-      update(row_position: row_dest, col_position: col_dest, moved: true)
-    elsif Game.find(game_id).black_player_id != user_id && row_dest == last_updated.row_position + 1 && col_dest == last_updated.col_position
-      last_updated.update(row_position: nil, col_position: nil, captured: true)
-      update(row_position: row_dest, col_position: col_dest, moved: true)
     end
   end
 
@@ -74,7 +42,6 @@ class Piece < ActiveRecord::Base
     true if game.pieces.find_by(row_position: row_dest, col_position: col_dest, user_id: user_id)
   end
 
-  # rubocop:disable Metrics/LineLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
   def obstructed?(row_dest, col_dest)
     # pass in row and col destination
     # get the current piece position

--- a/app/models/pieces/pawn.rb
+++ b/app/models/pieces/pawn.rb
@@ -1,26 +1,68 @@
 class Pawn < Piece
   after_update :update_previous_changes
 
-  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/LineLength
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/LineLength, Metrics/PerceivedComplexity, Metrics/MethodLength
   def valid_move?(row_dest, col_dest)
-    @adjacent_piece_r = Piece.find_by(row_position: row_position, col_position: col_position + 1)
-    @adjacent_piece_l = Piece.find_by(row_position: row_position, col_position: col_position - 1)
-    @last_updated = Piece.where(game_id: game_id).order("updated_at desc").first
-    if @adjacent_piece_r && @adjacent_piece_r.type == "Pawn"
-      return true if check_en_passant(row_dest, col_dest, @adjacent_piece_r, @last_updated)
-    elsif @adjacent_piece_l && @adjacent_piece_l.type = "Pawn"
-      return true if check_en_passant(row_dest, col_dest, @adjacent_piece_l, @last_updated)
-    end
+    return true if check_adjacent_pieces(row_dest, col_dest)
     row_diff = (row_position - row_dest).abs
     col_diff = (col_position - col_dest).abs
     return false if self.backward_move?(row_dest, col_dest) || self.horizontal_move?(row_dest, col_dest)
     return true if self.diagonal_move?(row_dest, col_dest) && col_diff == 1 && row_diff == 1 && game.pieces.find_by(row_position: row_dest, col_position: col_dest) && !self.own_piece?(row_dest, col_dest)
-    if self.vertical_move?(row_dest, col_dest) && !game.pieces.find_by(row_position: row_dest, col_position: col_dest)
-      return false if row_diff > 2
-      return true if row_position == 1 || row_position == 6 && row_diff <= 2
-      return true if row_diff == 1
+    return false unless self.vertical_move?(row_dest, col_dest) && !game.pieces.find_by(row_position: row_dest, col_position: col_dest)
+    return false if row_diff > 2
+    return true if row_position == 1 || row_position == 6 && row_diff <= 2 || row_diff == 1
+  end
+
+  def check_adjacent_pieces(new_row, new_col)
+    @last_updated = Piece.where(game_id: game_id).order("updated_at desc").first
+    @adjacent_piece_r = Piece.find_by(row_position: row_position, col_position: col_position + 1) if col_position != 7
+    @adjacent_piece_l = Piece.find_by(row_position: row_position, col_position: col_position - 1) if col_position != 0
+    if @adjacent_piece_l && @adjacent_piece_l.type == "Pawn" && @last_updated == @adjacent_piece_l
+      return true if check_en_passant(new_row, new_col, @last_updated)
+    elsif @adjacent_piece_r && @adjacent_piece_r.type == "Pawn" && @last_updated == @adjacent_piece_r
+      return true if check_en_passant(new_row, new_col, @last_updated)
     end
-    false
+  end
+
+  # Public: Check pawn for en passant
+  #
+  # row_dest, col_dest - destination coordinates
+  # adjacent_pawn - pawn next to Piece (also last updated Piece)
+  # last_updated - last updated Model
+  #
+  # Check if last updated Piece has relevant previous changes.
+  # Get the row_position of last updated and check if it had been moved.
+  # If the last move consisted of moving 2 rows and it had not been moved yet,
+  # the pawn can conduct an en passant
+  # and returns true, else false
+  def check_en_passant(row_dest, col_dest, last_updated)
+    return false if last_updated.prev_changes.nil?
+    return false if last_updated.prev_changes["moved"].nil? || last_updated.prev_changes["row_position"].nil?
+    # Convert string array stored in prev_changes into array
+    # rubocop:disable Lint/Eval
+    @last_updated_row = eval(last_updated.prev_changes["row_position"].gsub(/(\w+?)/, "'\\1'"))
+    @last_updated_moved = eval(last_updated.prev_changes["moved"].gsub(/(\w+?)/, "'\\1'"))
+    return false unless (@last_updated_row[0].to_i - @last_updated_row[1].to_i).abs == 2 && @last_updated_moved
+    if Game.find(game_id).black_player_id == user_id
+      return true if row_dest == last_updated.row_position - 1 && col_dest == last_updated.col_position
+    else
+      return true if row_dest == last_updated.row_position + 1 && col_dest == last_updated.col_position
+    end
+  end
+
+  def capture_en_passant!(row_dest, col_dest, last_updated)
+    # check player color and capture accordingly
+    if Game.find(game_id).black_player_id == user_id
+      if row_dest == last_updated.row_position - 1 && col_dest == last_updated.col_position
+        last_updated.update(row_position: nil, col_position: nil, captured: true)
+        update(row_position: row_dest, col_position: col_dest, moved: true)
+      end
+    else
+      if row_dest == last_updated.row_position + 1 && col_dest == last_updated.col_position
+        last_updated.update(row_position: nil, col_position: nil, captured: true)
+        update(row_position: row_dest, col_position: col_dest, moved: true)
+      end
+    end
   end
 
   def backward_move?(row_dest, _col_dest)
@@ -30,6 +72,6 @@ class Pawn < Piece
   private
 
   def update_previous_changes
-    update_column(:previous_changes_hash, changes)
+    update_column(:prev_changes, changes)
   end
 end

--- a/app/models/pieces/pawn.rb
+++ b/app/models/pieces/pawn.rb
@@ -1,6 +1,9 @@
 class Pawn < Piece
+  after_update :update_previous_changes
+
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/LineLength
   def valid_move?(row_dest, col_dest)
+    check_en_passant(row_dest, col_dest)
     row_diff = (row_position - row_dest).abs
     col_diff = (col_position - col_dest).abs
     return false if self.backward_move?(row_dest, col_dest) || self.horizontal_move?(row_dest, col_dest)
@@ -15,5 +18,24 @@ class Pawn < Piece
 
   def backward_move?(row_dest, _col_dest)
     user_id == game.white_player_id ? row_position > row_dest : row_position < row_dest
+  end
+
+  def check_en_passant(row_dest, col_dest)
+    @last_updated = Piece.where(game_id: game_id).order("updated_at desc").first
+    return if @last_updated.nil? || @last_updated.type != "Pawn" || @last_updated.previous_changes_hash.nil?
+    return if @last_updated.previous_changes_hash["moved"].nil? || @last_updated.previous_changes_hash["row_position"].nil?
+    @last_updated_row = @last_updated.previous_changes_hash["row_position"]
+    @last_updated_moved = @last_updated.previous_changes_hash["moved"][0]
+    return unless @last_updated.col_position == col_position + 1 || col_position - 1
+    return unless (@last_updated_row[0].to_i - @last_updated_row[1].to_i).abs == 2 && @last_updated_moved
+    valid_move_black = Game.find(game_id).black_player_id == user_id && row_dest == @last_updated.row_position - 1 && col_dest == @last_updated.col_position
+    valid_move_white = Game.find(game_id).black_player_id != user_id && row_dest == @last_updated.row_position + 1 && col_dest == @last_updated.col_position
+    valid_move_black || valid_move_white ? true : false
+  end
+
+  private
+
+  def update_previous_changes
+    update_column(:previous_changes_hash, changes)
   end
 end

--- a/app/models/pieces/pawn.rb
+++ b/app/models/pieces/pawn.rb
@@ -3,7 +3,14 @@ class Pawn < Piece
 
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/LineLength
   def valid_move?(row_dest, col_dest)
-    check_en_passant(row_dest, col_dest)
+    @adjacent_piece_r = Piece.find_by(row_position: row_position, col_position: col_position + 1)
+    @adjacent_piece_l = Piece.find_by(row_position: row_position, col_position: col_position - 1)
+    @last_updated = Piece.where(game_id: game_id).order("updated_at desc").first
+    if @adjacent_piece_r && @adjacent_piece_r.type == "Pawn"
+      return true if check_en_passant(row_dest, col_dest, @adjacent_piece_r, @last_updated)
+    elsif @adjacent_piece_l && @adjacent_piece_l.type = "Pawn"
+      return true if check_en_passant(row_dest, col_dest, @adjacent_piece_l, @last_updated)
+    end
     row_diff = (row_position - row_dest).abs
     col_diff = (col_position - col_dest).abs
     return false if self.backward_move?(row_dest, col_dest) || self.horizontal_move?(row_dest, col_dest)
@@ -18,19 +25,6 @@ class Pawn < Piece
 
   def backward_move?(row_dest, _col_dest)
     user_id == game.white_player_id ? row_position > row_dest : row_position < row_dest
-  end
-
-  def check_en_passant(row_dest, col_dest)
-    @last_updated = Piece.where(game_id: game_id).order("updated_at desc").first
-    return if @last_updated.nil? || @last_updated.type != "Pawn" || @last_updated.previous_changes_hash.nil?
-    return if @last_updated.previous_changes_hash["moved"].nil? || @last_updated.previous_changes_hash["row_position"].nil?
-    @last_updated_row = @last_updated.previous_changes_hash["row_position"]
-    @last_updated_moved = @last_updated.previous_changes_hash["moved"][0]
-    return unless @last_updated.col_position == col_position + 1 || col_position - 1
-    return unless (@last_updated_row[0].to_i - @last_updated_row[1].to_i).abs == 2 && @last_updated_moved
-    valid_move_black = Game.find(game_id).black_player_id == user_id && row_dest == @last_updated.row_position - 1 && col_dest == @last_updated.col_position
-    valid_move_white = Game.find(game_id).black_player_id != user_id && row_dest == @last_updated.row_position + 1 && col_dest == @last_updated.col_position
-    valid_move_black || valid_move_white ? true : false
   end
 
   private

--- a/db/migrate/20151203183224_add_previous_hash_to_pieces.rb
+++ b/db/migrate/20151203183224_add_previous_hash_to_pieces.rb
@@ -1,0 +1,6 @@
+class AddPreviousHashToPieces < ActiveRecord::Migration
+  def change
+  	enable_extension "hstore"
+  	add_column :pieces, :previous_changes_hash, :hstore
+  end
+end

--- a/db/migrate/20151205004803_change_previous_changes_hashto_prev_chang.rb
+++ b/db/migrate/20151205004803_change_previous_changes_hashto_prev_chang.rb
@@ -1,0 +1,5 @@
+class ChangePreviousChangesHashtoPrevChang < ActiveRecord::Migration
+  def change
+  	rename_column :pieces, :previous_changes_hash, :prev_changes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151126212020) do
+ActiveRecord::Schema.define(version: 20151203183224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "hstore"
 
   create_table "games", force: :cascade do |t|
     t.datetime "created_at",        null: false
@@ -29,15 +30,16 @@ ActiveRecord::Schema.define(version: 20151126212020) do
   add_index "games", ["white_player_id", "black_player_id"], name: "index_games_on_white_player_id_and_black_player_id", using: :btree
 
   create_table "pieces", force: :cascade do |t|
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.string   "type"
     t.integer  "row_position"
     t.integer  "col_position"
     t.integer  "game_id"
     t.integer  "user_id"
-    t.boolean  "captured",     default: false
-    t.boolean  "moved",        default: false
+    t.boolean  "captured",              default: false
+    t.boolean  "moved",                 default: false
+    t.hstore   "previous_changes_hash"
   end
 
   add_index "pieces", ["game_id", "user_id"], name: "index_pieces_on_game_id_and_user_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151203183224) do
+ActiveRecord::Schema.define(version: 20151205004803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,16 +30,16 @@ ActiveRecord::Schema.define(version: 20151203183224) do
   add_index "games", ["white_player_id", "black_player_id"], name: "index_games_on_white_player_id_and_black_player_id", using: :btree
 
   create_table "pieces", force: :cascade do |t|
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
     t.string   "type"
     t.integer  "row_position"
     t.integer  "col_position"
     t.integer  "game_id"
     t.integer  "user_id"
-    t.boolean  "captured",              default: false
-    t.boolean  "moved",                 default: false
-    t.hstore   "previous_changes_hash"
+    t.boolean  "captured",     default: false
+    t.boolean  "moved",        default: false
+    t.hstore   "prev_changes"
   end
 
   add_index "pieces", ["game_id", "user_id"], name: "index_pieces_on_game_id_and_user_id", using: :btree

--- a/test/models/pawn_test.rb
+++ b/test/models/pawn_test.rb
@@ -8,6 +8,26 @@ class PawnTest < ActiveSupport::TestCase
     @g.populate_board!
   end
 
+  test "Invalid En Passant" do
+    @black_pawn = @g.pieces.where(type: "Pawn").last
+    @white_pawn = Pawn.find_by(col_position: 6, game_id: @g.id)
+    @black_pawn.move_to!(3, 7)
+    @white_pawn.move_to!(2, 6)
+    @white_pawn.move_to!(3, 6)
+    @black_pawn.move_to!(2, 6) if @black_pawn.valid_move?(2, 6)
+    assert_equal 3, @black_pawn.reload.row_position
+  end
+
+  test "Valid En Passant" do
+    @black_pawn = @g.pieces.where(type: "Pawn").last
+    @white_pawn = Pawn.find_by(row_position: 1, col_position: 6, game_id: @g.id)
+    @black_pawn.move_to!(3, 7)
+    @white_pawn.move_to!(3, 6)
+    @black_pawn.move_to!(2, 6) if @black_pawn.valid_move?(2, 6)
+    assert_equal 2, @black_pawn.reload.row_position
+    assert_equal true, @white_pawn.reload.captured
+  end
+
   test "pawn valid move" do
     @pawn1 = Pawn.first
     expected = true

--- a/test/models/pawn_test.rb
+++ b/test/models/pawn_test.rb
@@ -28,7 +28,7 @@ class PawnTest < ActiveSupport::TestCase
     assert_equal 3, @black_pawn.reload.row_position
   end
 
-  test "Blocked En Passant should capture" do
+  test "Obstructed En Passant should capture" do
     @black_pawn = @g.pieces.where(type: "Pawn").last
     @white_pawn = Pawn.find_by(row_position: 1, col_position: 6, game_id: @g.id)
     @white_pawn_2 = Pawn.find_by(row_position: 1, col_position: 4, game_id: @g.id)
@@ -40,7 +40,7 @@ class PawnTest < ActiveSupport::TestCase
     assert_equal true, @white_pawn_2.reload.captured
   end
 
-  test "Invalid En Passant" do
+  test "En Passant attempt when last updated Pawn only moved 1 square in previous turn" do
     @black_pawn = @g.pieces.where(type: "Pawn").last
     @white_pawn = Pawn.find_by(col_position: 6, game_id: @g.id)
     @black_pawn.move_to!(3, 7)

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -5,120 +5,146 @@ class PieceTest < ActiveSupport::TestCase
     @user1 = FactoryGirl.create(:user)
     @user2 = FactoryGirl.create(:user)
     # rubocop:disable Metrics/LineLength
-    @piece1 = Piece.create(type: "Pawn", row_position: 4, col_position: 2, user_id: @user1.id, captured: false)
-    @piece2 = Piece.create(type: "Pawn", row_position: 5, col_position: 1, user_id: @user2.id, captured: false)
-    @piece3 = Piece.create(type: "Pawn", row_position: 5, col_position: 2, user_id: @user1.id, captured: false)
+    @piece1 = Piece.create(type: "Pawn", row_position: 4, col_position: 2, user_id: @user1.id, captured: false, game_id: 1)
+    @piece2 = Piece.create(type: "Pawn", row_position: 5, col_position: 1, user_id: @user2.id, captured: false, game_id: 1)
+    @piece3 = Piece.create(type: "Pawn", row_position: 5, col_position: 2, user_id: @user1.id, captured: false, game_id: 1)
     @g = Game.create(name: "New Game", white_player_id: @user1.id, black_player_id: @user2.id)
     @g.populate_board!
     @king = King.last
   end
 
-  test "unobstructed castling" do
-    Piece.find_by(row_position: 7, col_position: 6).destroy
-    Piece.find_by(row_position: 7, col_position: 5).destroy
-    @king.move_to!(7, 7)
-    expected = 6
-    actual = @king.reload.col_position
-    assert_equal expected, actual
+  # test "Invalid En Passant" do
+  #   @black_pawn = @g.pieces.where(type: "Pawn").last
+  #   @white_pawn = Pawn.find_by(col_position: 6, game_id: @g.id)
+  #   @black_pawn.move_to!(3, 7)
+  #   @white_pawn.move_to!(2, 6)
+  #   @white_pawn.move_to!(3, 6)
+  #   @black_pawn.move_to!(2, 6) if @black_pawn.valid_move?(2, 6)
+  #   assert_equal 3, @black_pawn.reload.row_position
+  # end
+
+  test "Valid En Passant" do
+    @black_pawn = @g.pieces.where(type: "Pawn").last
+    @white_pawn = Pawn.find_by(row_position: 1, col_position: 6, game_id: @g.id)
+    @black_pawn.move_to!(3, 7)
+    @white_pawn.move_to!(3, 6)
+    @black_pawn.move_to!(2, 6) if @black_pawn.valid_move?(2, 6)
+    assert_equal 2, @black_pawn.reload.row_position
+    assert_equal true, @white_pawn.reload.captured
   end
 
-  test "obstructed castling" do
-    @king.move_to!(7, 7)
-    assert_equal 4, @king.reload.col_position
-  end
+  # test "unobstructed castling" do
+  #   Piece.find_by(row_position: 7, col_position: 6).destroy
+  #   Piece.find_by(row_position: 7, col_position: 5).destroy
+  #   @king.move_to!(7, 7)
+  #   expected = 6
+  #   actual = @king.reload.col_position
+  #   assert_equal expected, actual
+  # end
 
-  test "capture pawn with other pawn" do
-    @piece1.move_to!(5, 1)
-    expected = true
-    actual = @piece2.reload.captured
-    assert_equal expected, actual
-    assert @piece1.row_position == 5 && @piece1.col_position == 1
-  end
+  # test "obstructed castling" do
+  #   @king.move_to!(7, 7)
+  #   assert_equal 4, @king.reload.col_position
+  # end
 
-  test "move to blank cell" do
-    @piece1.move_to!(6, 2)
-    assert @piece1.row_position == 6 && @piece1.col_position == 2
-  end
+  # test "capture pawn with other pawn" do
+  #   black_pawn = Pawn.last
+  #   white_pawn = Pawn.first
+  #   white_pawn.update(row_position: 5, col_position: 1)
+  #   black_pawn.move_to!(5, 1)
+  #   expected = true
+  #   actual = white_pawn.reload.captured
+  #   assert_equal expected, actual
+  #   assert black_pawn.row_position == 5 && black_pawn.col_position == 1
+  # end
 
-  test "same user" do
-    @piece1.move_to!(5, 2)
-    assert @piece1.row_position == 4 && @piece1.col_position == 2
-  end
+  # test "move to blank cell" do
+  #   black_pawn = Pawn.last
+  #   black_pawn.move_to!(5, 0)
+  #   assert black_pawn.row_position == 5 && black_pawn.col_position == 0
+  # end
 
-  test "obstructed?" do
-    # test moving to a destination where there is a piece but no obstruction
-    # get the black pawn, set it to captured, test rook can move to white pawn in same column
-    @pawn_black = Piece.where(row_position: 6, col_position: 0).first
-    @pawn_black.update(captured: true)
-    @rook_black = Piece.where(row_position: 7, col_position: 0).first
+  # test "same user" do
+  #   black_pawn = Pawn.last
+  #   Pawn.find_by(row_position: 6, col_position: 1).update(row_position: 5, col_position: 0)
+  #   black_pawn.move_to!(5, 0)
+  #   assert black_pawn.row_position == 6 && black_pawn.col_position == 0
+  # end
 
-    expected = false
-    actual = @rook_black.obstructed?(1, 0)
-    assert_equal expected, actual
+  # test "obstructed?" do
+  #   # test moving to a destination where there is a piece but no obstruction
+  #   # get the black pawn, set it to captured, test rook can move to white pawn in same column
+  #   @pawn_black = Piece.where(row_position: 6, col_position: 0).first
+  #   @pawn_black.update(captured: true)
+  #   @rook_black = Piece.where(row_position: 7, col_position: 0).first
 
-    # test rook_black for a horizontal move where there is an obstruction
-    expected = true
-    actual = @rook_black.obstructed?(7, 2)
-    assert_equal expected, actual
+  #   expected = false
+  #   actual = @rook_black.obstructed?(1, 0)
+  #   assert_equal expected, actual
 
-    # test is_obstructed? for a knight
-    @knight_white = Piece.where(row_position: 0, col_position: 1).first
+  #   # test rook_black for a horizontal move where there is an obstruction
+  #   expected = true
+  #   actual = @rook_black.obstructed?(7, 2)
+  #   assert_equal expected, actual
 
-    expected = "Invalid input! Knight can't be obstructed."
-    actual = @knight_white.obstructed?(2, 2)
-    assert_equal expected, actual
+  #   # test is_obstructed? for a knight
+  #   @knight_white = Piece.where(row_position: 0, col_position: 1).first
 
-    # test for obstruction where move is diagonal
-    @bishop_white = Piece.where(row_position: 0, col_position: 2).first
+  #   expected = "Invalid input! Knight can't be obstructed."
+  #   actual = @knight_white.obstructed?(2, 2)
+  #   assert_equal expected, actual
 
-    expected = true
-    actual = @bishop_white.obstructed?(2, 4)
-    assert_equal expected, actual
-  end
+  #   # test for obstruction where move is diagonal
+  #   @bishop_white = Piece.where(row_position: 0, col_position: 2).first
 
-  test "horizontal move" do
-    @rook_black = Piece.where(row_position: 7, col_position: 0).first
-    expected = true
-    actual = @rook_black.horizontal_move?(7, 3)
-    assert_equal expected, actual
+  #   expected = true
+  #   actual = @bishop_white.obstructed?(2, 4)
+  #   assert_equal expected, actual
+  # end
 
-    expected = false
-    actual = @rook_black.horizontal_move?(5, 3)
-    assert_equal expected, actual
-  end
+  # test "horizontal move" do
+  #   @rook_black = Piece.where(row_position: 7, col_position: 0).first
+  #   expected = true
+  #   actual = @rook_black.horizontal_move?(7, 3)
+  #   assert_equal expected, actual
 
-  test "vertical move" do
-    @rook_black = Piece.where(row_position: 7, col_position: 0).first
-    expected = true
-    actual = @rook_black.vertical_move?(5, 0)
-    assert_equal expected, actual
+  #   expected = false
+  #   actual = @rook_black.horizontal_move?(5, 3)
+  #   assert_equal expected, actual
+  # end
 
-    expected = false
-    actual = @rook_black.vertical_move?(7, 3)
-    assert_equal expected, actual
-  end
+  # test "vertical move" do
+  #   @rook_black = Piece.where(row_position: 7, col_position: 0).first
+  #   expected = true
+  #   actual = @rook_black.vertical_move?(5, 0)
+  #   assert_equal expected, actual
 
-  test "diagonal move" do
-    @bishop_black = Piece.where(row_position: 7, col_position: 5).first
-    expected = true
-    actual = @bishop_black.diagonal_move?(5, 3)
-    assert_equal expected, actual
+  #   expected = false
+  #   actual = @rook_black.vertical_move?(7, 3)
+  #   assert_equal expected, actual
+  # end
 
-    # testing a horizontal move
-    expected = false
-    actual = @bishop_black.diagonal_move?(7, 3)
-    assert_equal expected, actual
+  # test "diagonal move" do
+  #   @bishop_black = Piece.where(row_position: 7, col_position: 5).first
+  #   expected = true
+  #   actual = @bishop_black.diagonal_move?(5, 3)
+  #   assert_equal expected, actual
 
-    # testing a vertical move
-    expected = false
-    actual = @bishop_black.diagonal_move?(5, 5)
-    assert_equal expected, actual
-  end
+  #   # testing a horizontal move
+  #   expected = false
+  #   actual = @bishop_black.diagonal_move?(7, 3)
+  #   assert_equal expected, actual
 
-  test "own piece?" do
-    @bishop_black = Piece.where(row_position: 7, col_position: 5).first
-    expected = true
-    actual = @bishop_black.own_piece?(7, 4)
-    assert_equal expected, actual
-  end
+  #   # testing a vertical move
+  #   expected = false
+  #   actual = @bishop_black.diagonal_move?(5, 5)
+  #   assert_equal expected, actual
+  # end
+
+  # test "own piece?" do
+  #   @bishop_black = Piece.where(row_position: 7, col_position: 5).first
+  #   expected = true
+  #   actual = @bishop_black.own_piece?(7, 4)
+  #   assert_equal expected, actual
+  # end
 end

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -4,10 +4,6 @@ class PieceTest < ActiveSupport::TestCase
   def setup
     @user1 = FactoryGirl.create(:user)
     @user2 = FactoryGirl.create(:user)
-    # rubocop:disable Metrics/LineLength
-    # @piece1 = Piece.create(type: "Pawn", row_position: 4, col_position: 2, user_id: @user1.id, captured: false, game_id: 1)
-    # @piece2 = Piece.create(type: "Pawn", row_position: 5, col_position: 1, user_id: @user2.id, captured: false, game_id: 1)
-    # @piece3 = Piece.create(type: "Pawn", row_position: 5, col_position: 2, user_id: @user1.id, captured: false, game_id: 1)
     @g = Game.create(name: "New Game", white_player_id: @user1.id, black_player_id: @user2.id)
     @g.populate_board!
   end

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -5,146 +5,127 @@ class PieceTest < ActiveSupport::TestCase
     @user1 = FactoryGirl.create(:user)
     @user2 = FactoryGirl.create(:user)
     # rubocop:disable Metrics/LineLength
-    @piece1 = Piece.create(type: "Pawn", row_position: 4, col_position: 2, user_id: @user1.id, captured: false, game_id: 1)
-    @piece2 = Piece.create(type: "Pawn", row_position: 5, col_position: 1, user_id: @user2.id, captured: false, game_id: 1)
-    @piece3 = Piece.create(type: "Pawn", row_position: 5, col_position: 2, user_id: @user1.id, captured: false, game_id: 1)
+    # @piece1 = Piece.create(type: "Pawn", row_position: 4, col_position: 2, user_id: @user1.id, captured: false, game_id: 1)
+    # @piece2 = Piece.create(type: "Pawn", row_position: 5, col_position: 1, user_id: @user2.id, captured: false, game_id: 1)
+    # @piece3 = Piece.create(type: "Pawn", row_position: 5, col_position: 2, user_id: @user1.id, captured: false, game_id: 1)
     @g = Game.create(name: "New Game", white_player_id: @user1.id, black_player_id: @user2.id)
     @g.populate_board!
+  end
+
+  test "unobstructed castling" do
     @king = King.last
+    Piece.find_by(row_position: 7, col_position: 6).destroy
+    Piece.find_by(row_position: 7, col_position: 5).destroy
+    @king.move_to!(7, 7)
+    expected = 6
+    actual = @king.reload.col_position
+    assert_equal expected, actual
   end
 
-  # test "Invalid En Passant" do
-  #   @black_pawn = @g.pieces.where(type: "Pawn").last
-  #   @white_pawn = Pawn.find_by(col_position: 6, game_id: @g.id)
-  #   @black_pawn.move_to!(3, 7)
-  #   @white_pawn.move_to!(2, 6)
-  #   @white_pawn.move_to!(3, 6)
-  #   @black_pawn.move_to!(2, 6) if @black_pawn.valid_move?(2, 6)
-  #   assert_equal 3, @black_pawn.reload.row_position
-  # end
-
-  test "Valid En Passant" do
-    @black_pawn = @g.pieces.where(type: "Pawn").last
-    @white_pawn = Pawn.find_by(row_position: 1, col_position: 6, game_id: @g.id)
-    @black_pawn.move_to!(3, 7)
-    @white_pawn.move_to!(3, 6)
-    @black_pawn.move_to!(2, 6) if @black_pawn.valid_move?(2, 6)
-    assert_equal 2, @black_pawn.reload.row_position
-    assert_equal true, @white_pawn.reload.captured
+  test "obstructed castling" do
+    @king = King.last
+    @king.move_to!(7, 7)
+    assert_equal 4, @king.reload.col_position
   end
 
-  # test "unobstructed castling" do
-  #   Piece.find_by(row_position: 7, col_position: 6).destroy
-  #   Piece.find_by(row_position: 7, col_position: 5).destroy
-  #   @king.move_to!(7, 7)
-  #   expected = 6
-  #   actual = @king.reload.col_position
-  #   assert_equal expected, actual
-  # end
+  test "capture pawn with other pawn" do
+    black_pawn = Pawn.last
+    white_pawn = Pawn.first
+    white_pawn.update(row_position: 5, col_position: 1)
+    black_pawn.move_to!(5, 1)
+    expected = true
+    actual = white_pawn.reload.captured
+    assert_equal expected, actual
+    assert black_pawn.row_position == 5 && black_pawn.col_position == 1
+  end
 
-  # test "obstructed castling" do
-  #   @king.move_to!(7, 7)
-  #   assert_equal 4, @king.reload.col_position
-  # end
+  test "move to blank cell" do
+    black_pawn = Pawn.last
+    black_pawn.move_to!(5, 0)
+    assert black_pawn.row_position == 5 && black_pawn.col_position == 0
+  end
 
-  # test "capture pawn with other pawn" do
-  #   black_pawn = Pawn.last
-  #   white_pawn = Pawn.first
-  #   white_pawn.update(row_position: 5, col_position: 1)
-  #   black_pawn.move_to!(5, 1)
-  #   expected = true
-  #   actual = white_pawn.reload.captured
-  #   assert_equal expected, actual
-  #   assert black_pawn.row_position == 5 && black_pawn.col_position == 1
-  # end
+  test "same user" do
+    black_pawn = Pawn.last
+    Pawn.find_by(row_position: 6, col_position: 1).update(row_position: 5, col_position: 0)
+    black_pawn.move_to!(5, 0)
+    assert black_pawn.row_position == 6 && black_pawn.col_position == 0
+  end
 
-  # test "move to blank cell" do
-  #   black_pawn = Pawn.last
-  #   black_pawn.move_to!(5, 0)
-  #   assert black_pawn.row_position == 5 && black_pawn.col_position == 0
-  # end
+  test "obstructed?" do
+    # test moving to a destination where there is a piece but no obstruction
+    # get the black pawn, set it to captured, test rook can move to white pawn in same column
+    @pawn_black = Piece.where(row_position: 6, col_position: 0).first
+    @pawn_black.update(captured: true)
+    @rook_black = Piece.where(row_position: 7, col_position: 0).first
 
-  # test "same user" do
-  #   black_pawn = Pawn.last
-  #   Pawn.find_by(row_position: 6, col_position: 1).update(row_position: 5, col_position: 0)
-  #   black_pawn.move_to!(5, 0)
-  #   assert black_pawn.row_position == 6 && black_pawn.col_position == 0
-  # end
+    expected = false
+    actual = @rook_black.obstructed?(1, 0)
+    assert_equal expected, actual
 
-  # test "obstructed?" do
-  #   # test moving to a destination where there is a piece but no obstruction
-  #   # get the black pawn, set it to captured, test rook can move to white pawn in same column
-  #   @pawn_black = Piece.where(row_position: 6, col_position: 0).first
-  #   @pawn_black.update(captured: true)
-  #   @rook_black = Piece.where(row_position: 7, col_position: 0).first
+    # test rook_black for a horizontal move where there is an obstruction
+    expected = true
+    actual = @rook_black.obstructed?(7, 2)
+    assert_equal expected, actual
 
-  #   expected = false
-  #   actual = @rook_black.obstructed?(1, 0)
-  #   assert_equal expected, actual
+    # test is_obstructed? for a knight
+    @knight_white = Piece.where(row_position: 0, col_position: 1).first
 
-  #   # test rook_black for a horizontal move where there is an obstruction
-  #   expected = true
-  #   actual = @rook_black.obstructed?(7, 2)
-  #   assert_equal expected, actual
+    expected = "Invalid input! Knight can't be obstructed."
+    actual = @knight_white.obstructed?(2, 2)
+    assert_equal expected, actual
 
-  #   # test is_obstructed? for a knight
-  #   @knight_white = Piece.where(row_position: 0, col_position: 1).first
+    # test for obstruction where move is diagonal
+    @bishop_white = Piece.where(row_position: 0, col_position: 2).first
 
-  #   expected = "Invalid input! Knight can't be obstructed."
-  #   actual = @knight_white.obstructed?(2, 2)
-  #   assert_equal expected, actual
+    expected = true
+    actual = @bishop_white.obstructed?(2, 4)
+    assert_equal expected, actual
+  end
 
-  #   # test for obstruction where move is diagonal
-  #   @bishop_white = Piece.where(row_position: 0, col_position: 2).first
+  test "horizontal move" do
+    @rook_black = Piece.where(row_position: 7, col_position: 0).first
+    expected = true
+    actual = @rook_black.horizontal_move?(7, 3)
+    assert_equal expected, actual
 
-  #   expected = true
-  #   actual = @bishop_white.obstructed?(2, 4)
-  #   assert_equal expected, actual
-  # end
+    expected = false
+    actual = @rook_black.horizontal_move?(5, 3)
+    assert_equal expected, actual
+  end
 
-  # test "horizontal move" do
-  #   @rook_black = Piece.where(row_position: 7, col_position: 0).first
-  #   expected = true
-  #   actual = @rook_black.horizontal_move?(7, 3)
-  #   assert_equal expected, actual
+  test "vertical move" do
+    @rook_black = Piece.where(row_position: 7, col_position: 0).first
+    expected = true
+    actual = @rook_black.vertical_move?(5, 0)
+    assert_equal expected, actual
 
-  #   expected = false
-  #   actual = @rook_black.horizontal_move?(5, 3)
-  #   assert_equal expected, actual
-  # end
+    expected = false
+    actual = @rook_black.vertical_move?(7, 3)
+    assert_equal expected, actual
+  end
 
-  # test "vertical move" do
-  #   @rook_black = Piece.where(row_position: 7, col_position: 0).first
-  #   expected = true
-  #   actual = @rook_black.vertical_move?(5, 0)
-  #   assert_equal expected, actual
+  test "diagonal move" do
+    @bishop_black = Piece.where(row_position: 7, col_position: 5).first
+    expected = true
+    actual = @bishop_black.diagonal_move?(5, 3)
+    assert_equal expected, actual
 
-  #   expected = false
-  #   actual = @rook_black.vertical_move?(7, 3)
-  #   assert_equal expected, actual
-  # end
+    # testing a horizontal move
+    expected = false
+    actual = @bishop_black.diagonal_move?(7, 3)
+    assert_equal expected, actual
 
-  # test "diagonal move" do
-  #   @bishop_black = Piece.where(row_position: 7, col_position: 5).first
-  #   expected = true
-  #   actual = @bishop_black.diagonal_move?(5, 3)
-  #   assert_equal expected, actual
+    # testing a vertical move
+    expected = false
+    actual = @bishop_black.diagonal_move?(5, 5)
+    assert_equal expected, actual
+  end
 
-  #   # testing a horizontal move
-  #   expected = false
-  #   actual = @bishop_black.diagonal_move?(7, 3)
-  #   assert_equal expected, actual
-
-  #   # testing a vertical move
-  #   expected = false
-  #   actual = @bishop_black.diagonal_move?(5, 5)
-  #   assert_equal expected, actual
-  # end
-
-  # test "own piece?" do
-  #   @bishop_black = Piece.where(row_position: 7, col_position: 5).first
-  #   expected = true
-  #   actual = @bishop_black.own_piece?(7, 4)
-  #   assert_equal expected, actual
-  # end
+  test "own piece?" do
+    @bishop_black = Piece.where(row_position: 7, col_position: 5).first
+    expected = true
+    actual = @bishop_black.own_piece?(7, 4)
+    assert_equal expected, actual
+  end
 end


### PR DESCRIPTION
# En Passant
* [Overview of En Passant](http://www.chess.com/chessopedia/view/en-passant)
  * En passant (from French: "in passing") is a maneuver in chess which is performed after a player moves a pawn two squares forward from its starting position, and an opposing pawn captures it as if it had only moved one square.  En passant may only be played immediately after a two-square square pawn advance, or the right to capture "in passing" is lost.
* Checks to see if En Passant is possible in `valid_move?`
  * Checks if there are adjacent Pawns that match the last updated Piece
  * Checks if that Pawn moved 2 squares in the previous move
* Checks to see if En Passant is possible in `move_to!`
  * If it is possible, capture!

### Testing
* Valid En Passant Move
* En Passant attempt when the last updated Pawn only moved 1 square in previous turn
* En Passant moves when destination coordinate is obstructed (should still capture piece)
* En Passant attempt when the adjacent piece is not a pawn
* En Passant move when there are two adjacent pieces