### PR TITLE
Prevent player from making move when its not their turn

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,3 @@ DEPENDENCIES
   spring
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
-
-BUNDLED WITH
-   1.10.6

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -1,4 +1,6 @@
 class PiecesController < ApplicationController
+  before_action :check_player_color
+
   # rubocop:disable Metrics/AbcSize
   def show
     @piece = Piece.find(params[:id])
@@ -38,6 +40,13 @@ class PiecesController < ApplicationController
   end
 
   private
+
+  def check_player_color
+    @game = Game.find(params[:game_id])
+    return if @game.whos_turn? == current_user.id
+    flash[:alert] = "Not your turn!"
+    redirect_to game_path(@game)
+  end
 
   def piece_params
     params.require(:piece).permit(:type, :row_position, :col_position)

--- a/test/controllers/pieces_controller_test.rb
+++ b/test/controllers/pieces_controller_test.rb
@@ -1,10 +1,12 @@
 require 'test_helper'
-# rubocop:disable Metrics/LineLength
+# rubocop:disable Metrics/LineLength, Metrics/AbcSize
 class PiecesControllerTest < ActionController::TestCase
   def setup
     @user = FactoryGirl.create(:user)
-    @g = Game.create(name: "Test", white_player_id: @user.id, black_player_id: 3, turn_number: 0)
+    @user2 = FactoryGirl.create(:user)
+    @g = Game.create(name: "Test", white_player_id: @user.id, black_player_id: @user2.id, turn_number: 0)
     @pawn = Piece.create(type: "Pawn", col_position: 1, row_position: 1, user_id: @user.id, game_id: @g.id)
+    @black_pawn = Piece.create(type: "Pawn", col_position: 1, row_position: 6, user_id: @user2.id, game_id: @g.id)
     @white_rook_queenside = Piece.create(type: "Rook", col_position: 0, row_position: 0, user_id: @user.id, game_id: @g.id)
     @white_rook_kingside = Piece.create(type: "Rook", col_position: 7, row_position: 0, user_id: @user.id, game_id: @g.id)
   end
@@ -15,9 +17,17 @@ class PiecesControllerTest < ActionController::TestCase
   #   assert_response :success
   # end
 
+  test "Player that is not its turn should not be able to update" do
+    sign_in @user
+    sign_in @user2
+    put :update, id: @black_pawn.id, game_id: @g.id, piece: { type: @black_pawn.type, col_position: 2, row_position: 2 }
+    assert_equal 6, @black_pawn.row_position
+    assert_redirected_to game_path(@g)
+  end
+
   test "should update piece location" do
     sign_in @user
-    put :update, id: @pawn.id, piece: { type: @pawn.type, col_position: 2, row_position: 2 }
+    put :update, id: @pawn.id, game_id: @g.id, piece: { type: @pawn.type, col_position: 2, row_position: 2 }
     @pawn.reload
     @g.reload
 


### PR DESCRIPTION
# Prevents user from making move when its not their turn

* Added a `before_action` callback to check to see if the player attempting to make a move is their turn
* Added test to see if a move by a player when it's not their turn doesn't update the piece coordinates and redirects them to the original chess board