### PR TITLE
Valid_move for moves

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -9,12 +9,11 @@ class Piece < ActiveRecord::Base
       capture_en_passant!(new_row, new_col, @last_updated) && return
     end
     check_if_castling(new_row, new_col) if type == "King"
-    if valid_move?(new_row, new_col) # rubocop:disable Style/GuardClause
-      update(row_position: new_row, col_position: new_col, moved: true) && return unless @piece
-      if @piece.user_id != user_id
-        @piece.update(row_position: nil, col_position: nil, captured: true)
-        update(row_position: new_row, col_position: new_col, moved: true)
-      end
+    return unless valid_move?(new_row, new_col)
+    update(row_position: new_row, col_position: new_col, moved: true) && return unless @piece
+    if @piece.user_id != user_id # rubocop:disable Style/GuardClause
+      @piece.update(row_position: nil, col_position: nil, captured: true)
+      update(row_position: new_row, col_position: new_col, moved: true)
     end
   end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -8,12 +8,14 @@ class Piece < ActiveRecord::Base
     if type == "Pawn" && check_adjacent_pieces(new_row, new_col)
       capture_en_passant!(new_row, new_col, @last_updated)
     end
-    update(row_position: new_row, col_position: new_col, moved: true) && return unless @piece
-    if @piece.user_id != user_id
-      @piece.update(row_position: nil, col_position: nil, captured: true)
-      update(row_position: new_row, col_position: new_col, moved: true)
-    else
-      check_if_castling(new_row, new_col)
+    if valid_move?(new_row, new_col)
+      update(row_position: new_row, col_position: new_col, moved: true) && return unless @piece
+      if @piece.user_id != user_id
+        @piece.update(row_position: nil, col_position: nil, captured: true) 
+        update(row_position: new_row, col_position: new_col, moved: true)
+      else
+        check_if_castling(new_row, new_col)
+      end
     end
   end
 

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -11,10 +11,9 @@ class Piece < ActiveRecord::Base
     check_if_castling(new_row, new_col) if type == "King"
     return unless valid_move?(new_row, new_col)
     update(row_position: new_row, col_position: new_col, moved: true) && return unless @piece
-    if @piece.user_id != user_id # rubocop:disable Style/GuardClause
-      @piece.update(row_position: nil, col_position: nil, captured: true)
-      update(row_position: new_row, col_position: new_col, moved: true)
-    end
+    return unless @piece.user_id != user_id
+    @piece.update(row_position: nil, col_position: nil, captured: true)
+    update(row_position: new_row, col_position: new_col, moved: true)
   end
 
   def check_if_castling(row, col)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -8,13 +8,12 @@ class Piece < ActiveRecord::Base
     if type == "Pawn" && check_adjacent_pieces(new_row, new_col)
       capture_en_passant!(new_row, new_col, @last_updated) && return
     end
-    if valid_move?(new_row, new_col)
+    check_if_castling(new_row, new_col) if type == "King"
+    if valid_move?(new_row, new_col) # rubocop:disable Style/GuardClause
       update(row_position: new_row, col_position: new_col, moved: true) && return unless @piece
       if @piece.user_id != user_id
-        @piece.update(row_position: nil, col_position: nil, captured: true) 
+        @piece.update(row_position: nil, col_position: nil, captured: true)
         update(row_position: new_row, col_position: new_col, moved: true)
-      else
-        check_if_castling(new_row, new_col)
       end
     end
   end

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -85,7 +85,7 @@ class GameTest < ActiveSupport::TestCase
     @white_bishop = @game.pieces.create(type: "Bishop", col_position: 2, row_position: 1, user_id: @user1.id)
     @black_king = @game.pieces.create(type: "King", col_position: 2, row_position: 3, user_id: @user2.id)
 
-    @white_bishop.move_to!(4, 3)
+    @white_bishop.move_to!(3, 4)
 
     expected = true
     assert_equal expected, @game.determine_check

--- a/test/models/pawn_test.rb
+++ b/test/models/pawn_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-# rubocop:disable Metrics/LineLength, Metrics/ClassLength
+# rubocop:disable Metrics/LineLength
 class PawnTest < ActiveSupport::TestCase
   def setup
     @user1 = FactoryGirl.create(:user)
@@ -29,7 +29,7 @@ class PawnTest < ActiveSupport::TestCase
     @black_pawn = Pawn.create(row_position: 3, col_position: 7, game_id: @g.id, user_id: @user2.id)
     @white_pawn = Pawn.create(row_position: 3, col_position: 6, game_id: @g.id, user_id: @user1.id)
     @white_pawn_2 = Pawn.create(row_position: 2, col_position: 6, game_id: @g.id, user_id: @user1.id)
-    @black_pawn.move_to!(2, 6) 
+    @black_pawn.move_to!(2, 6)
     assert_equal 2, @black_pawn.reload.row_position
     assert_equal true, @white_pawn_2.reload.captured
   end

--- a/test/models/pawn_test.rb
+++ b/test/models/pawn_test.rb
@@ -9,54 +9,46 @@ class PawnTest < ActiveSupport::TestCase
   end
 
   test "En Passant with adjacent pieces on both sides" do
-    @black_pawn = @g.pieces.where(type: "Pawn").last
+    @black_pawn = Pawn.create(row_position: 3, col_position: 5, game_id: @g.id, user_id: @user2.id)
     @white_pawn = Pawn.find_by(row_position: 1, col_position: 6, game_id: @g.id)
     @white_pawn_2 = Pawn.find_by(row_position: 1, col_position: 4, game_id: @g.id)
-    @black_pawn.move_to!(3, 5)
     @white_pawn.move_to!(3, 6)
     @white_pawn_2.move_to!(3, 4)
-    @black_pawn.move_to!(2, 4) if @black_pawn.valid_move?(2, 4)
+    @black_pawn.move_to!(2, 4)
     assert_equal 2, @black_pawn.reload.row_position
   end
 
   test "En Passant when Adjacent Piece is not a Pawn" do
-    @black_pawn = @g.pieces.where(type: "Pawn").last
-    @white_rook = Rook.find_by(row_position: 0, col_position: 7, game_id: @g.id)
-    @black_pawn.move_to!(3, 7)
-    @white_rook.move_to!(3, 6)
-    @black_pawn.move_to!(2, 6) if @black_pawn.valid_move?(2, 6)
+    @black_pawn = Pawn.create(row_position: 3, col_position: 0, game_id: @g.id, user_id: @user2.id)
+    @white_rook = Rook.create(row_position: 3, col_position: 1, game_id: @g.id, user_id: @user1.id)
+    @black_pawn.move_to!(2, 1)
     assert_equal 3, @black_pawn.reload.row_position
   end
 
   test "Obstructed En Passant should capture" do
-    @black_pawn = @g.pieces.where(type: "Pawn").last
-    @white_pawn = Pawn.find_by(row_position: 1, col_position: 6, game_id: @g.id)
-    @white_pawn_2 = Pawn.find_by(row_position: 1, col_position: 4, game_id: @g.id)
-    @black_pawn.move_to!(3, 7)
-    @white_pawn.move_to!(3, 6)
-    @white_pawn_2.move_to!(2, 6)
-    @black_pawn.move_to!(2, 6) if @black_pawn.valid_move?(2, 6)
+    @black_pawn = Pawn.create(row_position: 3, col_position: 7, game_id: @g.id, user_id: @user2.id)
+    @white_pawn = Pawn.create(row_position: 3, col_position: 6, game_id: @g.id, user_id: @user1.id)
+    @white_pawn_2 = Pawn.create(row_position: 2, col_position: 6, game_id: @g.id, user_id: @user1.id)
+    @black_pawn.move_to!(2, 6) 
     assert_equal 2, @black_pawn.reload.row_position
     assert_equal true, @white_pawn_2.reload.captured
   end
 
   test "En Passant attempt when last updated Pawn only moved 1 square in previous turn" do
-    @black_pawn = @g.pieces.where(type: "Pawn").last
+    @black_pawn = Pawn.create(row_position: 3, col_position: 7, game_id: @g.id, user_id: @user2.id)
     @white_pawn = Pawn.find_by(col_position: 6, game_id: @g.id)
-    @black_pawn.move_to!(3, 7)
     @white_pawn.move_to!(2, 6)
     @white_pawn.move_to!(3, 6)
-    @black_pawn.move_to!(2, 6) if @black_pawn.valid_move?(2, 6)
+    @black_pawn.move_to!(2, 6)
     assert_equal 3, @black_pawn.reload.row_position
     assert_equal false, @white_pawn.reload.captured
   end
 
   test "Valid En Passant" do
-    @black_pawn = @g.pieces.where(type: "Pawn").last
+    @black_pawn = Pawn.create(row_position: 3, col_position: 7, game_id: @g.id, user_id: @user2.id)
     @white_pawn = Pawn.find_by(row_position: 1, col_position: 6, game_id: @g.id)
-    @black_pawn.move_to!(3, 7)
     @white_pawn.move_to!(3, 6)
-    @black_pawn.move_to!(2, 6) if @black_pawn.valid_move?(2, 6)
+    @black_pawn.move_to!(2, 6)
     assert_equal 2, @black_pawn.reload.row_position
     assert_equal true, @white_pawn.reload.captured
   end

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-
+# rubocop:disable Metrics/ClassLength
 class PieceTest < ActiveSupport::TestCase
   def setup
     @user1 = FactoryGirl.create(:user)
@@ -24,6 +24,7 @@ class PieceTest < ActiveSupport::TestCase
     assert_equal 4, @king.reload.col_position
   end
 
+  # rubocop:disable Metrics/LineLength
   test "valid pawn capture with move_to!" do
     black_pawn = Pawn.last
     white_pawn = Pawn.create(row_position: 5, col_position: 1, game_id: @g.id, user_id: @user1.id)
@@ -47,12 +48,30 @@ class PieceTest < ActiveSupport::TestCase
     assert black_pawn.row_position == 6 && black_pawn.col_position == 0
   end
 
-  test "invalid move for pawn" do 
+  test "invalid move for pawn" do
     # Pawn is at (6, 0)
     pawn = Pawn.last
     pawn.move_to!(5, 7)
     pawn.reload
     assert pawn.row_position == 6 && pawn.col_position == 0
+  end
+
+  test "valid move for king" do
+    # King is at (7, 4)
+    king = King.last
+    @g.pieces.find_by(row_position: 6, col_position: 4).destroy
+    king.move_to!(6, 4)
+    king.reload
+    assert king.row_position == 6 && king.col_position == 4
+  end
+
+  test "invalid move for king" do
+    # King is at (7, 4)
+    king = King.last
+    @g.pieces.find_by(row_position: 6, col_position: 4).destroy
+    king.move_to!(5, 4)
+    king.reload
+    assert king.row_position == 7 && king.col_position == 4
   end
 
   test "obstructed?" do
@@ -132,7 +151,7 @@ class PieceTest < ActiveSupport::TestCase
     assert_equal expected, actual
   end
 
-  test "not own piece?" do 
+  test "not own piece?" do
     @bishop_black = Piece.where(row_position: 7, col_position: 5).first
     expected = false
     actual = @bishop_black.own_piece?(1, 5)

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -24,10 +24,9 @@ class PieceTest < ActiveSupport::TestCase
     assert_equal 4, @king.reload.col_position
   end
 
-  test "capture pawn with other pawn" do
+  test "valid pawn capture with move_to!" do
     black_pawn = Pawn.last
-    white_pawn = Pawn.first
-    white_pawn.update(row_position: 5, col_position: 1)
+    white_pawn = Pawn.create(row_position: 5, col_position: 1, game_id: @g.id, user_id: @user1.id)
     black_pawn.move_to!(5, 1)
     expected = true
     actual = white_pawn.reload.captured
@@ -35,17 +34,25 @@ class PieceTest < ActiveSupport::TestCase
     assert black_pawn.row_position == 5 && black_pawn.col_position == 1
   end
 
-  test "move to blank cell" do
+  test "valid move to blank square" do
     black_pawn = Pawn.last
     black_pawn.move_to!(5, 0)
     assert black_pawn.row_position == 5 && black_pawn.col_position == 0
   end
 
-  test "same user" do
+  test "invalid move to square with your own piece" do
     black_pawn = Pawn.last
     Pawn.find_by(row_position: 6, col_position: 1).update(row_position: 5, col_position: 0)
     black_pawn.move_to!(5, 0)
     assert black_pawn.row_position == 6 && black_pawn.col_position == 0
+  end
+
+  test "invalid move for pawn" do 
+    # Pawn is at (6, 0)
+    pawn = Pawn.last
+    pawn.move_to!(5, 7)
+    pawn.reload
+    assert pawn.row_position == 6 && pawn.col_position == 0
   end
 
   test "obstructed?" do
@@ -122,6 +129,13 @@ class PieceTest < ActiveSupport::TestCase
     @bishop_black = Piece.where(row_position: 7, col_position: 5).first
     expected = true
     actual = @bishop_black.own_piece?(7, 4)
+    assert_equal expected, actual
+  end
+
+  test "not own piece?" do 
+    @bishop_black = Piece.where(row_position: 7, col_position: 5).first
+    expected = false
+    actual = @bishop_black.own_piece?(1, 5)
     assert_equal expected, actual
   end
 end


### PR DESCRIPTION
I've integrated `valid_move?` with `move_to!`.  I initially had some trouble getting the castling tests to work, but then realized that castling is not strictly a "valid move" for a King (ie. the King will move 2 squares rather than the usual 1).  Just like we did with en passant, the `move_to!` method needed to return sooner if we were castling.  

I've also had to update some of the tests that were written, specifically the ones for en passant, because we were using `move_to!` but the moves we were doing were not valid.  All of the tests pass now and I've written a few new ones to make sure that regular king movement still works like normal. 