### PR TITLE
Prevent moving to check

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class Piece < ActiveRecord::Base
   belongs_to :user
   belongs_to :game
@@ -23,44 +24,26 @@ class Piece < ActiveRecord::Base
     # the user is white
     if user_id == game.white_player_id
       opponent_pieces = game.pieces.where(user_id: game.black_player_id)
-      # puts col_position
-      # puts row_position
       row_pos = row_position
-      col_pos = col_position 
+      col_pos = col_position
 
       # temporarily moving the piece to the new location
       update(row_position: row_dest, col_position: col_dest)
-      # self.row_position = row_dest
-      # self.col_position = col_dest
-      
       king = game.pieces.find_by(user_id: game.white_player_id, type: "King")
-      # if self.type == "King"
-      #   king.row_position = row_dest
-      #   king.col_position = col_dest
-      # end  
-
 
       opponent_pieces.each do |piece|
         if piece.valid_move?(king.row_position, king.col_position)
           # returning the piece to its previous location
           update(row_position: row_pos, col_position: col_pos)
-          # self.row_position = row_pos
-          # self.col_position = col_pos
-          puts "you can't move into check"
-          #flash[:alert] = "You can't move into check" flash[:notice] =""
           return true
         end
       end
-      # making sure we're not changing data
-      # self.row_position = row_pos
-      # self.col_position = col_pos
-
-      return false    
+      return false
     # the user is black
     else
       opponent_pieces = game.pieces.where(user_id: game.white_player_id)
       row_pos = row_position
-      col_pos = col_position 
+      col_pos = col_position
       # temporarily moving the piece to the new location
       update(row_position: row_dest, col_position: col_dest)
       king = game.pieces.find_by(user_id: game.black_player_id, type: "King")
@@ -68,11 +51,9 @@ class Piece < ActiveRecord::Base
         if piece.valid_move?(king.row_position, king.col_position)
           # returning the piece to its previous location
           update(row_position: row_pos, col_position: col_pos)
-          puts "you can't move into check"
           return true
         end
       end
-      
       return false
     end
   end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 class Piece < ActiveRecord::Base
   belongs_to :user
   belongs_to :game
@@ -21,43 +20,15 @@ class Piece < ActiveRecord::Base
   end
 
   def moving_into_check?(row_dest, col_dest)
-    # the user is white
-    if user_id == game.white_player_id
-      opponent_pieces = game.pieces.where(user_id: game.black_player_id)
-      row_pos = row_position
-      col_pos = col_position
-
-      # temporarily moving the piece to the new location
-      update(row_position: row_dest, col_position: col_dest)
-      king = game.pieces.find_by(user_id: game.white_player_id, type: "King")
-
-      opponent_pieces.each do |piece|
-        if piece.valid_move?(king.row_position, king.col_position)
-          # returning the piece to its previous location
-          update(row_position: row_pos, col_position: col_pos)
-          return true
-        else
-          next
-        end
-      end
-      return false
-    # the user is black
+    row_pos = row_position
+    col_pos = col_position
+    # temporarily moving the piece to the new location
+    update(row_position: row_dest, col_position: col_dest)
+    in_check = game.determine_check
+    if in_check
+      update(row_position: row_pos, col_position: col_pos)
+      return true
     else
-      opponent_pieces = game.pieces.where(user_id: game.white_player_id)
-      row_pos = row_position
-      col_pos = col_position
-      # temporarily moving the piece to the new location
-      update(row_position: row_dest, col_position: col_dest)
-      king = game.pieces.find_by(user_id: game.black_player_id, type: "King")
-      opponent_pieces.each do |piece|
-        if piece.valid_move?(king.row_position, king.col_position)
-          # returning the piece to its previous location
-          update(row_position: row_pos, col_position: col_pos)
-          return true
-        else
-          next
-        end
-      end
       return false
     end
   end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -36,6 +36,8 @@ class Piece < ActiveRecord::Base
           # returning the piece to its previous location
           update(row_position: row_pos, col_position: col_pos)
           return true
+        else
+          next
         end
       end
       return false
@@ -52,6 +54,8 @@ class Piece < ActiveRecord::Base
           # returning the piece to its previous location
           update(row_position: row_pos, col_position: col_pos)
           return true
+        else
+          next
         end
       end
       return false

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -30,19 +30,31 @@ class Piece < ActiveRecord::Base
 
       # temporarily moving the piece to the new location
       update(row_position: row_dest, col_position: col_dest)
+      # self.row_position = row_dest
+      # self.col_position = col_dest
       
       king = game.pieces.find_by(user_id: game.white_player_id, type: "King")
-      
+      # if self.type == "King"
+      #   king.row_position = row_dest
+      #   king.col_position = col_dest
+      # end  
+
+
       opponent_pieces.each do |piece|
         if piece.valid_move?(king.row_position, king.col_position)
           # returning the piece to its previous location
           update(row_position: row_pos, col_position: col_pos)
+          # self.row_position = row_pos
+          # self.col_position = col_pos
           puts "you can't move into check"
           #flash[:alert] = "You can't move into check" flash[:notice] =""
           return true
         end
       end
-      
+      # making sure we're not changing data
+      # self.row_position = row_pos
+      # self.col_position = col_pos
+
       return false    
     # the user is black
     else

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -19,6 +19,52 @@ class Piece < ActiveRecord::Base
     update(row_position: new_row, col_position: new_col, moved: true)
   end
 
+  def moving_into_check?(row_dest, col_dest)
+    # the user is white
+    if user_id == game.white_player_id
+      opponent_pieces = game.pieces.where(user_id: game.black_player_id)
+      # puts col_position
+      # puts row_position
+      row_pos = row_position
+      col_pos = col_position 
+
+      # temporarily moving the piece to the new location
+      update(row_position: row_dest, col_position: col_dest)
+      
+      king = game.pieces.find_by(user_id: game.white_player_id, type: "King")
+      
+      opponent_pieces.each do |piece|
+        if piece.valid_move?(king.row_position, king.col_position)
+          # returning the piece to its previous location
+          update(row_position: row_pos, col_position: col_pos)
+          puts "you can't move into check"
+          #flash[:alert] = "You can't move into check" flash[:notice] =""
+          return true
+        end
+      end
+      
+      return false    
+    # the user is black
+    else
+      opponent_pieces = game.pieces.where(user_id: game.white_player_id)
+      row_pos = row_position
+      col_pos = col_position 
+      # temporarily moving the piece to the new location
+      update(row_position: row_dest, col_position: col_dest)
+      king = game.pieces.find_by(user_id: game.black_player_id, type: "King")
+      opponent_pieces.each do |piece|
+        if piece.valid_move?(king.row_position, king.col_position)
+          # returning the piece to its previous location
+          update(row_position: row_pos, col_position: col_pos)
+          puts "you can't move into check"
+          return true
+        end
+      end
+      
+      return false
+    end
+  end
+
   def check_if_castling(row, col)
     @piece = Piece.find_by(row_position: row, col_position: col)
     return unless @piece && type == "King" && !moved && @piece.type == "Rook" && !@piece.moved

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -8,6 +8,61 @@ class PieceTest < ActiveSupport::TestCase
     @g.populate_board!
   end
 
+  test "king is not moving into check" do
+    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
+    #@white_bishop = @game.pieces.create(type: "Bishop", col_position: 4, row_position: 5, user_id: @user1.id)
+    @white_king = @game.pieces.create(type: "King", row_position: 1, col_position: 0, user_id: @user1.id)
+    @black_pawn = @game.pieces.create(type: "Pawn", row_position: 3, col_position: 0, user_id: @user2.id)
+
+    expected = false
+    actual = @white_king.moving_into_check?(1, 1)
+    assert_equal expected, actual
+  end
+
+  test "king is moving into check" do
+    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
+    #@white_bishop = @game.pieces.create(type: "Bishop", col_position: 4, row_position: 5, user_id: @user1.id)
+    @white_king = @game.pieces.create(type: "King", row_position: 1, col_position: 0, user_id: @user1.id)
+    @black_pawn = @game.pieces.create(type: "Pawn", row_position: 3, col_position: 0, user_id: @user2.id)
+
+    expected = true
+    actual = @white_king.moving_into_check?(2, 1)
+    assert_equal expected, actual
+  end
+
+  test "king is moving into check2" do
+    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
+    @white_bishop = @game.pieces.create(type: "Bishop", row_position: 4, col_position: 5, user_id: @user1.id)
+    @white_king = @game.pieces.create(type: "King", row_position: 4, col_position: 6, user_id: @user1.id)
+    @black_queen = @game.pieces.create(type: "Queen", row_position: 2, col_position: 7, user_id: @user2.id)
+
+    expected = true
+    actual = @white_king.moving_into_check?(4, 7)
+    assert_equal expected, actual
+  end
+
+  test "queen is not moving into check" do
+    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
+    @white_bishop = @game.pieces.create(type: "Bishop", row_position: 4, col_position: 5, user_id: @user1.id)
+    @black_king = @game.pieces.create(type: "King", row_position: 2, col_position: 3, user_id: @user2.id)
+    @black_queen = @game.pieces.create(type: "Queen", row_position: 3, col_position: 2, user_id: @user2.id)
+
+    expected = false
+    actual = @black_queen.moving_into_check?(3, 4)
+    assert_equal expected, actual
+  end
+
+  test "queen is moving into check" do
+    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
+    @white_bishop = @game.pieces.create(type: "Bishop", row_position: 4, col_position: 5, user_id: @user1.id)
+    @black_king = @game.pieces.create(type: "King", row_position: 2, col_position: 3, user_id: @user2.id)
+    @black_queen = @game.pieces.create(type: "Queen", row_position: 3, col_position: 4, user_id: @user2.id)
+
+    expected = true
+    actual = @black_queen.moving_into_check?(3, 7)
+    assert_equal expected, actual
+  end
+
   test "unobstructed castling" do
     @king = King.last
     Piece.find_by(row_position: 7, col_position: 6).destroy

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -10,7 +10,6 @@ class PieceTest < ActiveSupport::TestCase
 
   test "king is not moving into check" do
     @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
-    #@white_bishop = @game.pieces.create(type: "Bishop", col_position: 4, row_position: 5, user_id: @user1.id)
     @white_king = @game.pieces.create(type: "King", row_position: 1, col_position: 0, user_id: @user1.id)
     @black_pawn = @game.pieces.create(type: "Pawn", row_position: 3, col_position: 0, user_id: @user2.id)
 
@@ -21,7 +20,6 @@ class PieceTest < ActiveSupport::TestCase
 
   test "king is moving into check" do
     @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
-    #@white_bishop = @game.pieces.create(type: "Bishop", col_position: 4, row_position: 5, user_id: @user1.id)
     @white_king = @game.pieces.create(type: "King", row_position: 1, col_position: 0, user_id: @user1.id)
     @black_pawn = @game.pieces.create(type: "Pawn", row_position: 3, col_position: 0, user_id: @user2.id)
 

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-# rubocop:disable Metrics/ClassLength
+# rubocop:disable Metrics/ClassLength, Metrics/LineLength
 class PieceTest < ActiveSupport::TestCase
   def setup
     @user1 = FactoryGirl.create(:user)
@@ -9,7 +9,7 @@ class PieceTest < ActiveSupport::TestCase
   end
 
   test "king is not moving into check" do
-    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
+    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 4)
     @white_king = @game.pieces.create(type: "King", row_position: 1, col_position: 0, user_id: @user1.id)
     @black_pawn = @game.pieces.create(type: "Pawn", row_position: 3, col_position: 0, user_id: @user2.id)
 
@@ -19,7 +19,7 @@ class PieceTest < ActiveSupport::TestCase
   end
 
   test "king is moving into check" do
-    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
+    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 4)
     @white_king = @game.pieces.create(type: "King", row_position: 1, col_position: 0, user_id: @user1.id)
     @black_pawn = @game.pieces.create(type: "Pawn", row_position: 3, col_position: 0, user_id: @user2.id)
 
@@ -29,7 +29,7 @@ class PieceTest < ActiveSupport::TestCase
   end
 
   test "king is moving into check2" do
-    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
+    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 4)
     @white_bishop = @game.pieces.create(type: "Bishop", row_position: 4, col_position: 5, user_id: @user1.id)
     @white_king = @game.pieces.create(type: "King", row_position: 4, col_position: 6, user_id: @user1.id)
     @black_queen = @game.pieces.create(type: "Queen", row_position: 2, col_position: 7, user_id: @user2.id)
@@ -40,7 +40,7 @@ class PieceTest < ActiveSupport::TestCase
   end
 
   test "bishop is moving into check" do
-    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
+    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 4)
     @white_bishop = @game.pieces.create(type: "Bishop", row_position: 3, col_position: 6, user_id: @user1.id)
     @white_king = @game.pieces.create(type: "King", row_position: 4, col_position: 5, user_id: @user1.id)
     @black_queen = @game.pieces.create(type: "Queen", row_position: 2, col_position: 7, user_id: @user2.id)
@@ -51,7 +51,7 @@ class PieceTest < ActiveSupport::TestCase
   end
 
   test "queen is not moving into check" do
-    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 4)
+    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
     @white_bishop = @game.pieces.create(type: "Bishop", row_position: 4, col_position: 5, user_id: @user1.id)
     @black_king = @game.pieces.create(type: "King", row_position: 2, col_position: 3, user_id: @user2.id)
     @black_queen = @game.pieces.create(type: "Queen", row_position: 3, col_position: 2, user_id: @user2.id)
@@ -62,7 +62,7 @@ class PieceTest < ActiveSupport::TestCase
   end
 
   test "queen is moving into check" do
-    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 4)
+    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
     @white_bishop = @game.pieces.create(type: "Bishop", row_position: 4, col_position: 5, user_id: @user1.id)
     @black_king = @game.pieces.create(type: "King", row_position: 2, col_position: 3, user_id: @user2.id)
     @black_queen = @game.pieces.create(type: "Queen", row_position: 3, col_position: 4, user_id: @user2.id)

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -41,8 +41,19 @@ class PieceTest < ActiveSupport::TestCase
     assert_equal expected, actual
   end
 
-  test "queen is not moving into check" do
+  test "bishop is moving into check" do
     @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
+    @white_bishop = @game.pieces.create(type: "Bishop", row_position: 3, col_position: 6, user_id: @user1.id)
+    @white_king = @game.pieces.create(type: "King", row_position: 4, col_position: 5, user_id: @user1.id)
+    @black_queen = @game.pieces.create(type: "Queen", row_position: 2, col_position: 7, user_id: @user2.id)
+
+    expected = true
+    actual = @white_bishop.moving_into_check?(4, 7)
+    assert_equal expected, actual
+  end
+
+  test "queen is not moving into check" do
+    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 4)
     @white_bishop = @game.pieces.create(type: "Bishop", row_position: 4, col_position: 5, user_id: @user1.id)
     @black_king = @game.pieces.create(type: "King", row_position: 2, col_position: 3, user_id: @user2.id)
     @black_queen = @game.pieces.create(type: "Queen", row_position: 3, col_position: 2, user_id: @user2.id)
@@ -53,7 +64,7 @@ class PieceTest < ActiveSupport::TestCase
   end
 
   test "queen is moving into check" do
-    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 3)
+    @game = Game.create(name: "A Game", white_player_id: @user1.id, black_player_id: @user2.id, turn_number: 4)
     @white_bishop = @game.pieces.create(type: "Bishop", row_position: 4, col_position: 5, user_id: @user1.id)
     @black_king = @game.pieces.create(type: "King", row_position: 2, col_position: 3, user_id: @user2.id)
     @black_queen = @game.pieces.create(type: "Queen", row_position: 3, col_position: 4, user_id: @user2.id)


### PR DESCRIPTION
Hi everybody,
1. I added a method in piece.rb that checks if the move that is about to be done is going to cause a check status. In order to do that, I temporarily uodated the location that the piece attempts to move to, and then called determine_check method. I don't think it's a good way to do that (update the database and then undo it). I thought to update the model, instead: 
instead of doing: 
update(row_position: row_dest, col_position: col_dest),
I tried:
      self.row_position = row_dest
      self.col_position = col_dest

But it didn't work, because valid_move checks the database later.

If anybody has an idea for a different approach to this method, let me know.

2. I have many rubocop errors of line lenght. Disabling it by  'Metrics/LineLength' doesn't seem to work here. Does anybody know why?

3. While writing the method, I might have found an error regarding 'who's turn it is'. Isn't white suppose to play when the turn number is odd? I think we have it the other way around.