### PR TITLE
Fixes ActiveRecord Dirty use & En Passant Bug

### DIFF
--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -6,7 +6,7 @@ class Piece < ActiveRecord::Base
   def move_to!(new_row, new_col)
     @piece = Piece.find_by(row_position: new_row, col_position: new_col)
     # Checking for En Passant
-    capture_en_passant!(new_row, new_col, @last_updated) && return if type == "Pawn" && check_adjacent_pieces(new_row, new_col)
+    capture_en_passant!(new_row, new_col) && return if type == "Pawn" && check_adjacent_pieces(new_row, new_col)
     # Execute castling procedures if piece is King
     castling(new_row, new_col) if type == "King"
     # Checking for Valid Move

--- a/app/models/pieces/pawn.rb
+++ b/app/models/pieces/pawn.rb
@@ -1,5 +1,5 @@
 class Pawn < Piece
-  after_update :update_previous_changes
+  after_save :update_previous_changes
 
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/LineLength, Metrics/PerceivedComplexity, Metrics/MethodLength
   def valid_move?(row_dest, col_dest)
@@ -50,16 +50,17 @@ class Pawn < Piece
     end
   end
 
-  def capture_en_passant!(row_dest, col_dest, last_updated)
+  def capture_en_passant!(row_dest, col_dest)
+    @last_updated = Piece.where(game_id: game_id).order("updated_at desc").first
     # check player color and capture accordingly
     if Game.find(game_id).black_player_id == user_id
-      if row_dest == last_updated.row_position - 1 && col_dest == last_updated.col_position
-        last_updated.update(row_position: nil, col_position: nil, captured: true)
+      if row_dest == @last_updated.row_position - 1 && col_dest == @last_updated.col_position
+        @last_updated.update(row_position: nil, col_position: nil, captured: true)
         update(row_position: row_dest, col_position: col_dest, moved: true)
       end
     else
-      if row_dest == last_updated.row_position + 1 && col_dest == last_updated.col_position
-        last_updated.update(row_position: nil, col_position: nil, captured: true)
+      if row_dest == @last_updated.row_position + 1 && col_dest == @last_updated.col_position
+        @last_updated.update(row_position: nil, col_position: nil, captured: true)
         update(row_position: row_dest, col_position: col_dest, moved: true)
       end
     end


### PR DESCRIPTION
# Fixes En Passsant Bug

* @ronny2205 and I encountered a bug where `changes` in `ActiveRecord Dirty` wasn't working as it waas supposed to
* I figured out that `changes` only unsaved attributes 

For example:

`person = Person.new`
`person.changes` = `{}`
`person.name = 'Bill'`
`person.name = 'Bob'`
`person.changes` = `{"name" => ["Bill", "Bob"]}`

On the other hand,

`person.update(name: 'Bob')`
`person.changes = {}`

Since I was using an `after_update` callback, this would not work.
I changed it to an `after_save` callback after getting a hint from [this post on Stack Overflow](http://stackoverflow.com/questions/1586536/how-to-detect-attribute-changes-from-model#comment14751921_1586641)