### PR TITLE
Optimize ActiveRecord Queries

### DIFF
--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -73,18 +73,6 @@ tr:nth-child(even) td:nth-child(odd), tr:nth-child(odd) td:nth-child(even) {
   list-style-type: none;
 }
 
-.flash-msg {
-  font-size: 18px;
-  font-weight: bold;
-  background: #FFF48F;
-  text-align:center;
-  display: block;
-  padding: 10px;
-  position:absolute;
-  left: 0;
-  right: 0;
-}
-
 .turn {
   color: #5bc0de;
   font-size: 20px;

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -28,7 +28,6 @@ class GamesController < ApplicationController
 
   def show
     @game = Game.find(params[:id])
-    @pieces = @game.pieces.all
   end
 
   def update

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -81,9 +81,6 @@ class GamesController < ApplicationController
   end
 
   def check_status
-    game = Game.find(params[:id])
-    ## max amount of players for checkmate is 16
-    return if game.pieces.count > 16
     stalemate?
     checkmate?
   end

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -1,6 +1,6 @@
 module GamesHelper
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/LineLength
-  def piece_present?(pieces, game, row_pos, col_pos)
+  def piece_present?(piece, game, row_pos, col_pos)
     white_pieces = {
       'Pawn'   => '&#9817;',
       'Rook'   => '&#9814;',
@@ -19,15 +19,14 @@ module GamesHelper
       'King' => '&#9818;'
     }
 
-    @piece = pieces.find_by(row_position: row_pos, col_position: col_pos)
-    if @piece && @piece.user_id == game.white_player_id
-      return content_tag(:span, white_pieces[@piece.type].html_safe, class: %w(piece move_mode), pos: "#{row_pos}#{col_pos}", id: "#{@piece.id}") if current_user.id == game.white_player_id && game.whos_turn? == game.white_player_id
-      return content_tag(:span, white_pieces[@piece.type].html_safe, class: ["piece"], pos: "#{row_pos}#{col_pos}", id: "#{@piece.id}")
-    elsif @piece && @piece.user_id == @game.black_player_id
-      return content_tag(:span, black_pieces[@piece.type].html_safe, class: %w(piece move_mode), pos: "#{row_pos}#{col_pos}", id: "#{@piece.id}") if current_user.id == game.black_player_id && game.whos_turn? == game.black_player_id
-      return content_tag(:span, black_pieces[@piece.type].html_safe, class: ["piece"], pos: "#{row_pos}#{col_pos}", id: "#{@piece.id}")
-    else
-      return tag(:span, class: ["piece"], pos: "#{row_pos}#{col_pos}")
+    return tag(:span, class: ["piece"], pos: "#{row_pos}#{col_pos}") if piece.nil?
+
+    if piece && piece.user_id == game.white_player_id
+      return content_tag(:span, white_pieces[piece.type].html_safe, class: %w(piece move_mode), pos: "#{row_pos}#{col_pos}", id: "#{piece.id}") if current_user.id == game.white_player_id && game.whos_turn? == game.white_player_id
+      return content_tag(:span, white_pieces[piece.type].html_safe, class: ["piece"], pos: "#{row_pos}#{col_pos}", id: "#{piece.id}")
+    elsif piece && piece.user_id == game.black_player_id
+      return content_tag(:span, black_pieces[piece.type].html_safe, class: %w(piece move_mode), pos: "#{row_pos}#{col_pos}", id: "#{piece.id}") if current_user.id == game.black_player_id && game.whos_turn? == game.black_player_id
+      return content_tag(:span, black_pieces[piece.type].html_safe, class: ["piece"], pos: "#{row_pos}#{col_pos}", id: "#{piece.id}")
     end
   end
 
@@ -51,15 +50,6 @@ module GamesHelper
   def my_turn?(game)
     return "<strong>Its your turn!</strong>".html_safe if current_user.id == game.whos_turn?
     "Its your opponent's turn"
-  end
-
-  def in_stalemate
-    return "Stalemate" if @game.determine_stalemate
-  end
-
-  def in_check
-    return "White player: Check" if @game.determine_check && @game.whos_turn? == @game.white_player_id
-    return "Black player: Check" if @game.determine_check && @game.whos_turn? == @game.black_player_id
   end
 
   def winning_player

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,20 +1,3 @@
-<% if @game.determine_check %>
-  <div class = "flash-msg"> 
-    <%= in_check %>
-  </div> 
-  <br/>
-<% end %>  
-
-
-<% if @game.determine_stalemate %>
-  <div class = "flash-msg"> 
-    <%= in_stalemate %>
-  </div> 
-  <br/>
-<% end %> 
-
-
-<br />
 <div class ="col-xs-3"></div>
 <div class="booyah-box col-xs-4">
   <h1 class="text-center pusherInfo" data-pusherinfo=<%= "channel-#{@game.id}" %> ><%= @game.name %></h1>
@@ -47,7 +30,8 @@
   <% 8.times do |row| %>
     <%= '<tr>'.html_safe %>
     <% 8.times do |col| %>
-      <%= '<td>'.html_safe + piece_present?(@pieces, @game, row, col) + '</td>'.html_safe %>
+      <% piece_result = @game.pieces.find { |p| p["col_position"] == col && p["row_position"] == row } %>
+      <%= '<td>'.html_safe + piece_present?(piece_result, @game, row, col) + '</td>'.html_safe %>
     <% end %> 
   <% end %>
 </table>


### PR DESCRIPTION
We were having some problems with Request Timeouts on Heroku because our ActiveRecord queries were taking too long. 

I didn't solve the problem with either Stalemate or Checkmate, but I did make the queries for gathering all of the pieces **95%** faster.  Original time: 44.2ms, current time: 2.2ms.  In local testing, it takes about 10s to render the Game#Show page, which isn't great, but it's better than before.  
